### PR TITLE
Get typings package back

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@ast-decorators/utils": "^0.1.0",
+    "@ast-decorators/typings": "^0.1.0",
     "@babel/types": "^7"
   }
 }

--- a/packages/core/src/class.ts
+++ b/packages/core/src/class.ts
@@ -1,5 +1,7 @@
-import {DecorableClass} from '@ast-decorators/utils/lib/commonTypes';
-import {ASTDecoratorPluginOptions} from '@ast-decorators/utils/src/commonTypes';
+import {
+  ASTDecoratorPluginOptions,
+  DecorableClass,
+} from '@ast-decorators/typings';
 import {NodePath} from '@babel/core';
 import {Decorator} from '@babel/types';
 import processDecorator from './processor';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,8 +1,8 @@
 import {
+  ASTDecoratorPluginOptions,
   DecorableClass,
   DecorableClassMember,
-} from '@ast-decorators/utils/lib/commonTypes';
-import {ASTDecoratorPluginOptions} from '@ast-decorators/utils/src/commonTypes';
+} from '@ast-decorators/typings';
 import {NodePath} from '@babel/core';
 import {Decorator} from '@babel/types';
 import processClassDecorator from './class';

--- a/packages/core/src/processor.ts
+++ b/packages/core/src/processor.ts
@@ -1,4 +1,4 @@
-import {ASTDecoratorPluginOptions} from '@ast-decorators/utils/src/commonTypes';
+import {ASTDecoratorPluginOptions} from '@ast-decorators/typings';
 import {NodePath} from '@babel/core';
 import {
   Decorator,
@@ -13,7 +13,7 @@ import {
 import {dirname, resolve} from 'path';
 import DecoratorMetadata, {PluginPass} from './utils';
 
-export type DecoratorProcessorArguments = {
+type DecoratorProcessorArguments = {
   call: readonly NodePath[];
   decorator: readonly NodePath[];
 };

--- a/packages/core/src/property.ts
+++ b/packages/core/src/property.ts
@@ -1,8 +1,8 @@
 import {
+  ASTDecoratorPluginOptions,
   DecorableClass,
   DecorableClassMember,
-} from '@ast-decorators/utils/lib/commonTypes';
-import {ASTDecoratorPluginOptions} from '@ast-decorators/utils/src/commonTypes';
+} from '@ast-decorators/typings';
 import {NodePath} from '@babel/core';
 import {Decorator, isClassDeclaration, isClassExpression} from '@babel/types';
 import processDecorator from './processor';

--- a/packages/typings/lib/index.d.ts
+++ b/packages/typings/lib/index.d.ts
@@ -16,17 +16,17 @@ export type DecorableClassMember =
   | ClassPrivateMethod;
 
 export type ASTDecoratorPluginOptions = Readonly<{
-  privacy: 'hard' | 'soft' | 'none';
-  override: Record<string, Omit<ASTDecoratorPluginOptions, 'override'>>;
+  privacy?: 'hard' | 'soft' | 'none';
+  override?: Record<string, Omit<ASTDecoratorPluginOptions, 'override'>>;
 }>;
 
 export type ASTClassDecorator = (
   klass: NodePath<DecorableClass>,
-  opts: ASTDecoratorPluginOptions,
+  opts?: ASTDecoratorPluginOptions,
 ) => void;
 
 export type ASTClassMemberDecorator = (
   klass: NodePath<DecorableClass>,
   member: NodePath<DecorableClassMember>,
-  opts: ASTDecoratorPluginOptions,
+  opts?: ASTDecoratorPluginOptions,
 ) => void;

--- a/packages/typings/package.json
+++ b/packages/typings/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@ast-decorators/typings",
+  "version": "0.1.0",
+  "description": "AST Decorators core plugin",
+  "main": "lib/index.js",
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  }
+}

--- a/packages/typings/tsconfig.json
+++ b/packages/typings/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig",
+  "include": ["lib/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,11 +20,16 @@
     "stripInternal": true,
     "target": "esnext"
   },
-  "include": ["packages/**/*", "utils/**/*", "jest.config.js"],
+  "include": [
+    "packages/**/*",
+    "packages/typings/lib/**/*",
+    "utils/**/*",
+    "jest.config.js"
+  ],
   "exclude": [
     "node_modules/!(@open-wc)",
     "packages/*/tests/fixtures/**/*",
-    "packages/*/lib/**/*",
+    "packages/!(typings)/lib/**/*",
     "packages/*/node_modules/**/*"
   ]
 }


### PR DESCRIPTION
This PR gets `@ast-decorators/typings` package back.

The reason is that if common typings are placed in the `@ast-decorators/utils` package, it creates circular dependency between `@ast-decorators/core` and `@ast-decorators/utils` because `core` uses common typings and `utils` uses `core`.

A separate package that does not have any internal dependency would solve this issue.