### PR TITLE
Add createPropertyByPrivacy util

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,3 @@
 packages/*/tests/fixtures/**/*
+packages/*/node_modules
+packages/*/lib

--- a/packages/typings/package.json
+++ b/packages/typings/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "AST Decorators core plugin",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit"
   }

--- a/packages/utils/package-lock.json
+++ b/packages/utils/package-lock.json
@@ -1,0 +1,33 @@
+{
+	"name": "@ast-decorators/utils",
+	"version": "0.1.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@babel/types": {
+			"version": "7.8.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
+			"integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.13",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+		},
+		"lodash": {
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+		}
+	}
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -9,5 +9,12 @@
     "build:dts": "tsc -p tsconfig.build.json --emitDeclarationOnly",
     "build:remove": "rimraf lib",
     "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@ast-decorators/typings": "^0.1.0",
+    "@babel/types": "^7"
+  },
+  "devDependencies": {
+    "@ast-decorators/core": "^0.1.0"
   }
 }

--- a/packages/utils/src/createPropertyByPrivacy.ts
+++ b/packages/utils/src/createPropertyByPrivacy.ts
@@ -1,0 +1,48 @@
+import {
+  ASTDecoratorPluginOptions,
+  DecorableClass,
+} from '@ast-decorators/typings';
+import {NodePath} from '@babel/core';
+import template from '@babel/template';
+import {
+  ClassBody,
+  classPrivateProperty,
+  ClassPrivateProperty,
+  ClassProperty,
+  classProperty,
+  Expression,
+  privateName,
+} from '@babel/types';
+
+const createSymbolAssignment = template.statement(`const VAR = Symbol()`);
+
+const createPropertyByPrivacy = (
+  privacy: ASTDecoratorPluginOptions['privacy'],
+  name: string | undefined,
+  value: Expression | null,
+  klass: NodePath<DecorableClass>,
+): ClassProperty | ClassPrivateProperty => {
+  switch (privacy) {
+    case 'hard': {
+      const classBody = klass.get('body') as NodePath<ClassBody>;
+      const id = classBody.scope.generateUidIdentifier(name);
+      const privateId = privateName(id);
+
+      return classPrivateProperty(privateId, value);
+    }
+    case 'soft': {
+      const id = klass.parentPath.scope.generateUidIdentifier(name);
+      klass.insertBefore([createSymbolAssignment({VAR: id})]);
+
+      return classProperty(id, value, null, null, true);
+    }
+    default: {
+      const classBody = klass.get('body') as NodePath<ClassBody>;
+      const id = classBody.scope.generateUidIdentifier(name);
+
+      return classProperty(id, value);
+    }
+  }
+};
+
+export default createPropertyByPrivacy;

--- a/packages/utils/tests/__snapshots__/createPropertyByPrivacy.ts.snap
+++ b/packages/utils/tests/__snapshots__/createPropertyByPrivacy.ts.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@ast-decorators/utils createPropertyByPrivacy compiles for decorator with hard privacy option 1`] = `
+"\\"use strict\\";
+
+class Foo {
+  #_bar = \\"baz\\";
+  bar;
+}"
+`;
+
+exports[`@ast-decorators/utils createPropertyByPrivacy compiles for decorator with none privacy option 1`] = `
+"\\"use strict\\";
+
+class Foo {
+  _bar = \\"baz\\";
+  bar;
+}"
+`;
+
+exports[`@ast-decorators/utils createPropertyByPrivacy compiles for decorator with soft privacy option 1`] = `
+"\\"use strict\\";
+
+const _bar = Symbol();
+
+class Foo {
+  [_bar] = \\"baz\\";
+  bar;
+}"
+`;

--- a/packages/utils/tests/createPropertyByPrivacy.ts
+++ b/packages/utils/tests/createPropertyByPrivacy.ts
@@ -1,0 +1,20 @@
+import {compare as _compare} from '../../../utils/testing';
+
+const compare = async (fixture: string): Promise<void> =>
+  _compare(__dirname, 'createPropertyByPrivacy', fixture);
+
+describe('@ast-decorators/utils', () => {
+  describe('createPropertyByPrivacy', () => {
+    it('compiles for decorator with hard privacy option', async () => {
+      await compare('hard');
+    });
+
+    it('compiles for decorator with soft privacy option', async () => {
+      await compare('soft');
+    });
+
+    it('compiles for decorator with none privacy option', async () => {
+      await compare('none');
+    });
+  });
+});

--- a/packages/utils/tests/fixtures/createPropertyByPrivacy/decorators.ts
+++ b/packages/utils/tests/fixtures/createPropertyByPrivacy/decorators.ts
@@ -1,0 +1,30 @@
+import {
+  ASTDecoratorPluginOptions,
+  DecorableClass,
+} from '@ast-decorators/typings';
+import {NodePath} from '@babel/core';
+import {
+  ClassBody,
+  ClassProperty,
+  Identifier,
+  stringLiteral,
+} from '@babel/types';
+import createPropertyByPrivacy from '../../../src/createPropertyByPrivacy';
+
+const foo: PropertyDecorator = ((
+  klass: NodePath<DecorableClass>,
+  member: NodePath<ClassProperty>,
+  {privacy = 'hard'}: ASTDecoratorPluginOptions = {},
+) => {
+  const storage = createPropertyByPrivacy(
+    privacy,
+    (member.node.key as Identifier).name,
+    stringLiteral('baz'),
+    klass,
+  );
+
+  const klassBody = klass.get('body') as NodePath<ClassBody>;
+  klassBody.unshiftContainer('body', [storage]);
+}) as any;
+
+export default foo;

--- a/packages/utils/tests/fixtures/createPropertyByPrivacy/hard/input.ts
+++ b/packages/utils/tests/fixtures/createPropertyByPrivacy/hard/input.ts
@@ -1,0 +1,6 @@
+import foo from '../decorators';
+
+// @ts-ignore
+class Foo {
+  @foo public bar?: string;
+}

--- a/packages/utils/tests/fixtures/createPropertyByPrivacy/hard/options.ts
+++ b/packages/utils/tests/fixtures/createPropertyByPrivacy/hard/options.ts
@@ -1,0 +1,10 @@
+export default {
+  comments: false,
+  presets: [require('@babel/preset-typescript')],
+  plugins: [
+    [require('@babel/plugin-transform-modules-commonjs')],
+    [require('@ast-decorators/core'), {privacy: 'hard'}],
+    [require('@babel/plugin-syntax-decorators'), {legacy: true}],
+    require('@babel/plugin-syntax-class-properties'),
+  ],
+};

--- a/packages/utils/tests/fixtures/createPropertyByPrivacy/none/input.ts
+++ b/packages/utils/tests/fixtures/createPropertyByPrivacy/none/input.ts
@@ -1,0 +1,6 @@
+import foo from '../decorators';
+
+// @ts-ignore
+class Foo {
+  @foo public bar?: string;
+}

--- a/packages/utils/tests/fixtures/createPropertyByPrivacy/none/options.ts
+++ b/packages/utils/tests/fixtures/createPropertyByPrivacy/none/options.ts
@@ -1,0 +1,10 @@
+export default {
+  comments: false,
+  presets: [require('@babel/preset-typescript')],
+  plugins: [
+    [require('@babel/plugin-transform-modules-commonjs')],
+    [require('@ast-decorators/core'), {privacy: 'none'}],
+    [require('@babel/plugin-syntax-decorators'), {legacy: true}],
+    require('@babel/plugin-syntax-class-properties'),
+  ],
+};

--- a/packages/utils/tests/fixtures/createPropertyByPrivacy/soft/input.ts
+++ b/packages/utils/tests/fixtures/createPropertyByPrivacy/soft/input.ts
@@ -1,0 +1,6 @@
+import foo from '../decorators';
+
+// @ts-ignore
+class Foo {
+  @foo public bar?: string;
+}

--- a/packages/utils/tests/fixtures/createPropertyByPrivacy/soft/options.ts
+++ b/packages/utils/tests/fixtures/createPropertyByPrivacy/soft/options.ts
@@ -1,0 +1,10 @@
+export default {
+  comments: false,
+  presets: [require('@babel/preset-typescript')],
+  plugins: [
+    [require('@babel/plugin-transform-modules-commonjs')],
+    [require('@ast-decorators/core'), {privacy: 'soft'}],
+    [require('@babel/plugin-syntax-decorators'), {legacy: true}],
+    require('@babel/plugin-syntax-class-properties'),
+  ],
+};


### PR DESCRIPTION
This PR introduces `createPropertyByPrivacy ` util that allows to create a class property basing on the `privacy` plugin option. The `privacy` option has three positions.

#### Hard
If `privacy` is set to `hard`, the property will be private.
```javascript
class Foo {
  #_bar;
}
```

#### Soft
If `privacy` is set to `soft`, the property will be symbolic.
```javascript
const _bar = Symbol();

class Foo {
  [_bar];
}
```

#### None
If `privacy` is set to `none`, the property will be regular.
```javascript
class Foo {
  _bar;
}
```