### PR TITLE
Context for interceptors

### DIFF
--- a/packages/transform-accessor/src/accessor.ts
+++ b/packages/transform-accessor/src/accessor.ts
@@ -33,12 +33,16 @@ const accessor: AccessorDecorator = ((
     member,
     get,
     storage.key as Identifier | PrivateName,
+    // TODO: Add option to set up context
+    true,
   );
   const setter = createSetterMethod(
     klass,
     member,
     set,
     storage.key as Identifier | PrivateName,
+    // TODO: Add option to set up context
+    true,
   );
 
   member.replaceWithMultiple([storage, getter, setter]);

--- a/packages/transform-accessor/src/getter.ts
+++ b/packages/transform-accessor/src/getter.ts
@@ -1,7 +1,6 @@
 import {NodePath} from '@babel/core';
 import {
   blockStatement,
-  callExpression,
   classMethod,
   ClassMethod,
   classPrivateMethod,
@@ -18,9 +17,9 @@ import {
 import {
   AccessorInterceptor,
   AccessorInterceptorNode,
-  createAccessorDecorator,
   AccessorMethodCreator,
-  generateAccessorInterceptor,
+  createAccessorDecorator,
+  injectInterceptor,
 } from './utils';
 
 export const createGetterMethod: AccessorMethodCreator = (
@@ -28,13 +27,21 @@ export const createGetterMethod: AccessorMethodCreator = (
   member,
   interceptor,
   storageProperty,
+  allowThisContext,
 ): ClassMethod | ClassPrivateMethod => {
-  const interceptorId = generateAccessorInterceptor(klass, interceptor, 'get');
   const value = memberExpression(thisExpression(), storageProperty);
 
   const body = blockStatement([
     returnStatement(
-      interceptorId ? callExpression(interceptorId, [value]) : value,
+      interceptor
+        ? injectInterceptor(
+            klass,
+            interceptor.node,
+            value,
+            'get',
+            allowThisContext,
+          )
+        : value,
     ),
   ]);
 

--- a/packages/transform-accessor/src/utils.ts
+++ b/packages/transform-accessor/src/utils.ts
@@ -161,7 +161,8 @@ export const injectInterceptor = (
 ): CallExpression => {
   const interceptorId = generateInterceptor(klass, interceptor, type);
 
-  return isArrowFunctionExpression(interceptor) || !allowThisContext
+  return isArrowFunctionExpression(interceptor) ||
+    (isIdentifier(interceptor) && !allowThisContext)
     ? callExpression(interceptorId, [value])
     : callExpression(memberExpression(interceptorId, identifier('call')), [
         thisExpression(),

--- a/packages/transform-accessor/tests/__snapshots__/getter.ts.snap
+++ b/packages/transform-accessor/tests/__snapshots__/getter.ts.snap
@@ -34,16 +34,16 @@ class Foo {
 exports[`@ast-decorators/transform-accessor @getter compiles for decorator with inline function interceptor 1`] = `
 "\\"use strict\\";
 
-const _getInterceptor = function (value) {
+function _getInterceptor(value) {
   console.log(value);
   return value;
-};
+}
 
 class Foo {
   #_bar;
 
   get bar() {
-    return _getInterceptor(this.#_bar);
+    return _getInterceptor.call(this, this.#_bar);
   }
 
 }"
@@ -61,7 +61,7 @@ class Foo {
   #_bar;
 
   get bar() {
-    return get(this.#_bar);
+    return get.call(this, this.#_bar);
   }
 
 }"

--- a/packages/transform-accessor/tests/__snapshots__/setter.ts.snap
+++ b/packages/transform-accessor/tests/__snapshots__/setter.ts.snap
@@ -34,16 +34,16 @@ class Foo {
 exports[`@ast-decorators/transform-accessor @setter compiles for decorator with inline function interceptor 1`] = `
 "\\"use strict\\";
 
-const _setInterceptor = function (value) {
+function _setInterceptor(value) {
   console.log(value);
   return value;
-};
+}
 
 class Foo {
   #_bar;
 
   set bar(_value) {
-    this.#_bar = _setInterceptor(_value);
+    this.#_bar = _setInterceptor.call(this, _value);
   }
 
 }"
@@ -61,7 +61,7 @@ class Foo {
   #_bar;
 
   set bar(_value) {
-    this.#_bar = set(_value);
+    this.#_bar = set.call(this, _value);
   }
 
 }"


### PR DESCRIPTION
This PR introduces `this` context for interceptors. Now it implements the following algorithm:

### Arrow function

If interceptor is an arrow function, it will be called as-is:

**input.js**

```javascript
class Foo {
  @getter(value => value) bar;
}
```

**output.js**

```javascript
const _getInterceptor = value => value;

class Foo {
  #_bar;

  get() {
    return _getInterceptor(this.#_bar);
  }
}
```

### Regular function

If interceptor is a regular function, it will be called with `this` context:

**input.js**

```javascript
class Foo {
  @getter(function(value) {
    return value;
  })
  bar;
}
```

**output.js**

```javascript
function _getInterceptor(value) {
  return value;
}

class Foo {
  #_bar;

  get() {
    return _getInterceptor.call(this, this.#_bar);
  }
}
```

### Identifier

If interceptor is an identifier (function, declared somewhere else, not directly in decorator), it will be called with context.

**input.js**

```javascript
import {get} from './get.js';

class Foo {
  @getter(get) bar;
}
```

**output.js**

```javascript
import {get} from './get.js';

class Foo {
  #_bar;

  get() {
    return get.call(this, this.#_bar);
  }
}
```
