### PR TITLE
Add test for decorators renaming

### DIFF
--- a/packages/core/tests/__snapshots__/class.ts.snap
+++ b/packages/core/tests/__snapshots__/class.ts.snap
@@ -46,3 +46,12 @@ class Link extends HTMLAnchorElement {}
 console.log('foo is 1');
 console.log('bar is 0');"
 `;
+
+exports[`@ast-decorators/core class compiles renamed decorators 1`] = `
+"\\"use strict\\";
+
+class Link extends HTMLAnchorElement {}
+
+console.log('foo is 1');
+console.log('bar is 0');"
+`;

--- a/packages/core/tests/class.ts
+++ b/packages/core/tests/class.ts
@@ -18,6 +18,10 @@ describe('@ast-decorators/core', () => {
       await compare('namespace');
     });
 
+    it('compiles renamed decorators', async () => {
+      await compare('rename');
+    });
+
     it('compiles decorators with params', async () => {
       await compare('params');
     });

--- a/packages/core/tests/fixtures/class/default/decorator.ts
+++ b/packages/core/tests/fixtures/class/default/decorator.ts
@@ -1,0 +1,19 @@
+import {DecorableClass} from '@ast-decorators/typings';
+import {template} from '@babel/core';
+import {NodePath} from '@babel/traverse';
+import {StringLiteral} from '@babel/types';
+
+const tpl = template.statements('customElements.define(NAME, CLASS)');
+
+export type ElementDecorator = (name: string) => ClassDecorator;
+
+export const element: ElementDecorator = ((name: NodePath<StringLiteral>) => (
+  klass: NodePath<DecorableClass>,
+) => {
+  const nodes = tpl({
+    CLASS: klass.node.id,
+    NAME: name.node,
+  });
+
+  klass.insertAfter(nodes);
+}) as any;

--- a/packages/core/tests/fixtures/class/rename/decorators.ts
+++ b/packages/core/tests/fixtures/class/rename/decorators.ts
@@ -1,0 +1,22 @@
+import {DecorableClass} from '@ast-decorators/typings';
+import {template} from '@babel/core';
+import {NodePath} from '@babel/traverse';
+import {Statement} from '@babel/types';
+
+let count = 0;
+
+export type CallableClassDecorator = () => ClassDecorator;
+
+export const foo: CallableClassDecorator = (() => (
+  klass: NodePath<DecorableClass>,
+) => {
+  const consoleTpl = template(`console.log('foo is ${count++}')`);
+
+  klass.insertAfter([consoleTpl() as Statement]);
+}) as any;
+
+export const bar: ClassDecorator = ((klass: NodePath<DecorableClass>) => {
+  const consoleTpl = template(`console.log('bar is ${count++}')`);
+
+  klass.insertAfter([consoleTpl() as Statement]);
+}) as any;

--- a/packages/core/tests/fixtures/class/rename/input.ts
+++ b/packages/core/tests/fixtures/class/rename/input.ts
@@ -1,0 +1,6 @@
+import {bar as b, foo as f} from './decorators';
+
+@f()
+@b
+// @ts-ignore
+class Link extends HTMLAnchorElement {}


### PR DESCRIPTION
This PR checks the ability of `@ast-decorators/core` to work with renamed decorators.
```javascript
import {foo as bar} from './foo';

@bar
class Foo {}
```