### PR TITLE
Add static accessors

### DIFF
--- a/packages/transform-accessor/src/accessor.ts
+++ b/packages/transform-accessor/src/accessor.ts
@@ -27,6 +27,7 @@ const accessor = (
     interceptorContext,
     privacy,
     singleAccessorDecorators,
+    useClassNameForStatic,
   }: TransformAccessorOptions = {},
   {filename},
 ) => {
@@ -36,6 +37,9 @@ const accessor = (
     ? (member.get('decorators') as ReadonlyArray<NodePath<Decorator>>)
     : null;
 
+  // @ts-ignore
+  const useClassName = !!member.node.static && !!useClassNameForStatic;
+
   const storage = createStorage(klass, member, privacy);
   const getter = createGetterMethod(
     klass,
@@ -44,6 +48,7 @@ const accessor = (
     storage.key as Identifier | PrivateName,
     {
       preservingDecorators: decorators?.map(({node}) => node) ?? null,
+      useClassName,
       useContext: shouldUseContext(get, interceptorContext, filename),
     },
   );
@@ -69,6 +74,7 @@ const accessor = (
     {
       preservingDecorators:
         bothAccessorsDecorators?.map(({node}) => node) ?? null,
+      useClassName,
       useContext: shouldUseContext(set, interceptorContext, filename),
     },
   );

--- a/packages/transform-accessor/tests/__snapshots__/accessor.ts.snap
+++ b/packages/transform-accessor/tests/__snapshots__/accessor.ts.snap
@@ -1,6 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`@ast-decorators/transform-accessor @accessor compiles for decorator without interceptors 1`] = `
+exports[`@ast-decorators/transform-accessor @accessor compiles for static property 1`] = `
+"class Foo {
+  static #_bar;
+
+  static get bar() {
+    return this.#_bar;
+  }
+
+  static set bar(_value) {
+    this.#_bar = _value;
+  }
+
+}"
+`;
+
+exports[`@ast-decorators/transform-accessor @accessor compiles without interceptors 1`] = `
 "class Foo {
   #_bar;
 

--- a/packages/transform-accessor/tests/__snapshots__/getter.ts.snap
+++ b/packages/transform-accessor/tests/__snapshots__/getter.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`@ast-decorators/transform-accessor @getter compiles for decorator on computed property 1`] = `
+exports[`@ast-decorators/transform-accessor @getter compiles for computed property 1`] = `
 "const $bar = Symbol();
 
 class Foo {
@@ -13,7 +13,7 @@ class Foo {
 }"
 `;
 
-exports[`@ast-decorators/transform-accessor @getter compiles for decorator on private property 1`] = `
+exports[`@ast-decorators/transform-accessor @getter compiles for private property 1`] = `
 "class Foo {
   #_bar;
 
@@ -24,7 +24,7 @@ exports[`@ast-decorators/transform-accessor @getter compiles for decorator on pr
 }"
 `;
 
-exports[`@ast-decorators/transform-accessor @getter compiles for decorator on property with assignment 1`] = `
+exports[`@ast-decorators/transform-accessor @getter compiles for property with assignment 1`] = `
 "class Foo {
   #_bar = 'baz';
 
@@ -35,7 +35,7 @@ exports[`@ast-decorators/transform-accessor @getter compiles for decorator on pr
 }"
 `;
 
-exports[`@ast-decorators/transform-accessor @getter compiles for decorator on static property 1`] = `
+exports[`@ast-decorators/transform-accessor @getter compiles for static property 1`] = `
 "class Foo {
   static #_bar;
 

--- a/packages/transform-accessor/tests/__snapshots__/getter.ts.snap
+++ b/packages/transform-accessor/tests/__snapshots__/getter.ts.snap
@@ -35,7 +35,18 @@ exports[`@ast-decorators/transform-accessor @getter compiles for decorator on pr
 }"
 `;
 
-exports[`@ast-decorators/transform-accessor @getter compiles for decorator without interceptor 1`] = `
+exports[`@ast-decorators/transform-accessor @getter compiles for decorator on static property 1`] = `
+"class Foo {
+  static #_bar;
+
+  static get bar() {
+    return this.#_bar;
+  }
+
+}"
+`;
+
+exports[`@ast-decorators/transform-accessor @getter compiles without interceptor 1`] = `
 "class Foo {
   #_bar;
 
@@ -176,4 +187,26 @@ class Foo {
   }
 
 }"
+`;
+
+exports[`@ast-decorators/transform-accessor @getter uses class name instead of this for static property 1`] = `
+"class Foo {
+  static #_bar;
+
+  static get bar() {
+    return Foo.#_bar;
+  }
+
+}"
+`;
+
+exports[`@ast-decorators/transform-accessor @getter uses this for static property if class name is absent 1`] = `
+"const Foo = class {
+  static #_bar;
+
+  static get bar() {
+    return this.#_bar;
+  }
+
+};"
 `;

--- a/packages/transform-accessor/tests/__snapshots__/setter.ts.snap
+++ b/packages/transform-accessor/tests/__snapshots__/setter.ts.snap
@@ -35,7 +35,18 @@ exports[`@ast-decorators/transform-accessor @setter compiles for decorator on pr
 }"
 `;
 
-exports[`@ast-decorators/transform-accessor @setter compiles for decorator without interceptor 1`] = `
+exports[`@ast-decorators/transform-accessor @setter compiles for decorator on static property 1`] = `
+"class Foo {
+  static #_bar;
+
+  static set bar(_value) {
+    this.#_bar = _value;
+  }
+
+}"
+`;
+
+exports[`@ast-decorators/transform-accessor @setter compiles without interceptor 1`] = `
 "class Foo {
   #_bar;
 
@@ -176,4 +187,26 @@ class Foo {
   }
 
 }"
+`;
+
+exports[`@ast-decorators/transform-accessor @setter uses class name instead of this for static property 1`] = `
+"class Foo {
+  static #_bar;
+
+  static set bar(_value) {
+    Foo.#_bar = _value;
+  }
+
+}"
+`;
+
+exports[`@ast-decorators/transform-accessor @setter uses this for static property if class name is absent 1`] = `
+"const Foo = class {
+  static #_bar;
+
+  static set bar(_value) {
+    this.#_bar = _value;
+  }
+
+};"
 `;

--- a/packages/transform-accessor/tests/__snapshots__/setter.ts.snap
+++ b/packages/transform-accessor/tests/__snapshots__/setter.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`@ast-decorators/transform-accessor @setter compiles for decorator on computed property 1`] = `
+exports[`@ast-decorators/transform-accessor @setter compiles for computed property 1`] = `
 "const $bar = Symbol();
 
 class Foo {
@@ -13,7 +13,18 @@ class Foo {
 }"
 `;
 
-exports[`@ast-decorators/transform-accessor @setter compiles for decorator on private property 1`] = `
+exports[`@ast-decorators/transform-accessor @setter compiles for on static property 1`] = `
+"class Foo {
+  static #_bar;
+
+  static set bar(_value) {
+    this.#_bar = _value;
+  }
+
+}"
+`;
+
+exports[`@ast-decorators/transform-accessor @setter compiles for private property 1`] = `
 "class Foo {
   #_bar;
 
@@ -24,22 +35,11 @@ exports[`@ast-decorators/transform-accessor @setter compiles for decorator on pr
 }"
 `;
 
-exports[`@ast-decorators/transform-accessor @setter compiles for decorator on property with assignment 1`] = `
+exports[`@ast-decorators/transform-accessor @setter compiles for property with assignment 1`] = `
 "class Foo {
   #_bar = 'baz';
 
   set bar(_value) {
-    this.#_bar = _value;
-  }
-
-}"
-`;
-
-exports[`@ast-decorators/transform-accessor @setter compiles for decorator on static property 1`] = `
-"class Foo {
-  static #_bar;
-
-  static set bar(_value) {
     this.#_bar = _value;
   }
 

--- a/packages/transform-accessor/tests/accessor.ts
+++ b/packages/transform-accessor/tests/accessor.ts
@@ -9,8 +9,12 @@ const compare = async (
 
 describe('@ast-decorators/transform-accessor', () => {
   describe('@accessor', () => {
-    it('compiles for decorator without interceptors', async () => {
+    it('compiles without interceptors', async () => {
       await compare('default', commonOptions);
+    });
+
+    it('compiles for static property', async () => {
+      await compare('static-property', commonOptions);
     });
 
     it('preserves following decorators for both accessors', async () => {

--- a/packages/transform-accessor/tests/fixtures/accessor/static-property/input.ts
+++ b/packages/transform-accessor/tests/fixtures/accessor/static-property/input.ts
@@ -1,0 +1,7 @@
+import {accessor} from '../../../../src';
+
+// @ts-ignore
+class Foo {
+  @accessor()
+  public static bar?: string;
+}

--- a/packages/transform-accessor/tests/fixtures/getter/static-property-class-name/input.ts
+++ b/packages/transform-accessor/tests/fixtures/getter/static-property-class-name/input.ts
@@ -1,0 +1,7 @@
+import {getter} from '../../../../src';
+
+// @ts-ignore
+class Foo {
+  @getter()
+  public static bar?: string;
+}

--- a/packages/transform-accessor/tests/fixtures/getter/static-property-class-name/options.ts
+++ b/packages/transform-accessor/tests/fixtures/getter/static-property-class-name/options.ts
@@ -1,0 +1,22 @@
+export default {
+  comments: false,
+  presets: [require('@babel/preset-typescript')],
+  plugins: [
+    [
+      require('@ast-decorators/core'),
+      {
+        transformers: [
+          [
+            require('../../../../src/transformer'),
+            {
+              transformerPath: '**/transform-accessor/src',
+              useClassNameForStatic: true,
+            },
+          ],
+        ],
+      },
+    ],
+    [require('@babel/plugin-syntax-decorators'), {legacy: true}],
+    require('@babel/plugin-syntax-class-properties'),
+  ],
+};

--- a/packages/transform-accessor/tests/fixtures/getter/static-property-no-class-name/input.ts
+++ b/packages/transform-accessor/tests/fixtures/getter/static-property-no-class-name/input.ts
@@ -1,0 +1,9 @@
+// @ts-ignore
+import {getter} from '../../../../src';
+
+// @ts-ignore
+const Foo = class {
+  // @ts-ignore
+  @getter()
+  public static bar?: string;
+};

--- a/packages/transform-accessor/tests/fixtures/getter/static-property-no-class-name/options.ts
+++ b/packages/transform-accessor/tests/fixtures/getter/static-property-no-class-name/options.ts
@@ -1,0 +1,22 @@
+export default {
+  comments: false,
+  presets: [require('@babel/preset-typescript')],
+  plugins: [
+    [
+      require('@ast-decorators/core'),
+      {
+        transformers: [
+          [
+            require('../../../../src/transformer'),
+            {
+              transformerPath: '**/transform-accessor/src',
+              useClassNameForStatic: true,
+            },
+          ],
+        ],
+      },
+    ],
+    [require('@babel/plugin-syntax-decorators'), {legacy: true}],
+    require('@babel/plugin-syntax-class-properties'),
+  ],
+};

--- a/packages/transform-accessor/tests/fixtures/getter/static-property/input.ts
+++ b/packages/transform-accessor/tests/fixtures/getter/static-property/input.ts
@@ -1,0 +1,7 @@
+import {getter} from '../../../../src';
+
+// @ts-ignore
+class Foo {
+  @getter()
+  public static bar?: string;
+}

--- a/packages/transform-accessor/tests/fixtures/setter/static-property-class-name/input.ts
+++ b/packages/transform-accessor/tests/fixtures/setter/static-property-class-name/input.ts
@@ -1,0 +1,7 @@
+import {setter} from '../../../../src';
+
+// @ts-ignore
+class Foo {
+  @setter()
+  public static bar?: string;
+}

--- a/packages/transform-accessor/tests/fixtures/setter/static-property-class-name/options.ts
+++ b/packages/transform-accessor/tests/fixtures/setter/static-property-class-name/options.ts
@@ -1,0 +1,22 @@
+export default {
+  comments: false,
+  presets: [require('@babel/preset-typescript')],
+  plugins: [
+    [
+      require('@ast-decorators/core'),
+      {
+        transformers: [
+          [
+            require('../../../../src/transformer'),
+            {
+              transformerPath: '**/transform-accessor/src',
+              useClassNameForStatic: true,
+            },
+          ],
+        ],
+      },
+    ],
+    [require('@babel/plugin-syntax-decorators'), {legacy: true}],
+    require('@babel/plugin-syntax-class-properties'),
+  ],
+};

--- a/packages/transform-accessor/tests/fixtures/setter/static-property-no-class-name/input.ts
+++ b/packages/transform-accessor/tests/fixtures/setter/static-property-no-class-name/input.ts
@@ -1,0 +1,9 @@
+// @ts-ignore
+import {setter} from '../../../../src';
+
+// @ts-ignore
+const Foo = class {
+  // @ts-ignore
+  @setter()
+  public static bar?: string;
+};

--- a/packages/transform-accessor/tests/fixtures/setter/static-property-no-class-name/options.ts
+++ b/packages/transform-accessor/tests/fixtures/setter/static-property-no-class-name/options.ts
@@ -1,0 +1,22 @@
+export default {
+  comments: false,
+  presets: [require('@babel/preset-typescript')],
+  plugins: [
+    [
+      require('@ast-decorators/core'),
+      {
+        transformers: [
+          [
+            require('../../../../src/transformer'),
+            {
+              transformerPath: '**/transform-accessor/src',
+              useClassNameForStatic: true,
+            },
+          ],
+        ],
+      },
+    ],
+    [require('@babel/plugin-syntax-decorators'), {legacy: true}],
+    require('@babel/plugin-syntax-class-properties'),
+  ],
+};

--- a/packages/transform-accessor/tests/fixtures/setter/static-property/input.ts
+++ b/packages/transform-accessor/tests/fixtures/setter/static-property/input.ts
@@ -1,0 +1,7 @@
+import {setter} from '../../../../src';
+
+// @ts-ignore
+class Foo {
+  @setter()
+  public static bar?: string;
+}

--- a/packages/transform-accessor/tests/getter.ts
+++ b/packages/transform-accessor/tests/getter.ts
@@ -18,7 +18,7 @@ const transformFile = async (
 
 describe('@ast-decorators/transform-accessor', () => {
   describe('@getter', () => {
-    it('compiles for decorator without interceptor', async () => {
+    it('compiles without interceptor', async () => {
       await compare('default', commonOptions);
     });
 
@@ -32,6 +32,18 @@ describe('@ast-decorators/transform-accessor', () => {
 
     it('compiles for decorator on computed property', async () => {
       await compare('computed-property', commonOptions);
+    });
+
+    it('compiles for decorator on static property', async () => {
+      await compare('static-property', commonOptions);
+    });
+
+    it('uses class name instead of this for static property', async () => {
+      await compare('static-property-class-name');
+    });
+
+    it('uses this for static property if class name is absent', async () => {
+      await compare('static-property-no-class-name');
     });
 
     it('fails if applied to something else than property', async () => {

--- a/packages/transform-accessor/tests/getter.ts
+++ b/packages/transform-accessor/tests/getter.ts
@@ -22,19 +22,19 @@ describe('@ast-decorators/transform-accessor', () => {
       await compare('default', commonOptions);
     });
 
-    it('compiles for decorator on private property', async () => {
+    it('compiles for private property', async () => {
       await compare('private-property', commonOptions);
     });
 
-    it('compiles for decorator on property with assignment', async () => {
+    it('compiles for property with assignment', async () => {
       await compare('property-assigning', commonOptions);
     });
 
-    it('compiles for decorator on computed property', async () => {
+    it('compiles for computed property', async () => {
       await compare('computed-property', commonOptions);
     });
 
-    it('compiles for decorator on static property', async () => {
+    it('compiles for static property', async () => {
       await compare('static-property', commonOptions);
     });
 

--- a/packages/transform-accessor/tests/setter.ts
+++ b/packages/transform-accessor/tests/setter.ts
@@ -18,7 +18,7 @@ const transformFile = async (
 
 describe('@ast-decorators/transform-accessor', () => {
   describe('@setter', () => {
-    it('compiles for decorator without interceptor', async () => {
+    it('compiles without interceptor', async () => {
       await compare('default', commonOptions);
     });
 
@@ -32,6 +32,18 @@ describe('@ast-decorators/transform-accessor', () => {
 
     it('compiles for decorator on computed property', async () => {
       await compare('computed-property', commonOptions);
+    });
+
+    it('compiles for decorator on static property', async () => {
+      await compare('static-property', commonOptions);
+    });
+
+    it('uses class name instead of this for static property', async () => {
+      await compare('static-property-class-name');
+    });
+
+    it('uses this for static property if class name is absent', async () => {
+      await compare('static-property-no-class-name');
     });
 
     it('fails if applied to something else than property', async () => {

--- a/packages/transform-accessor/tests/setter.ts
+++ b/packages/transform-accessor/tests/setter.ts
@@ -22,19 +22,19 @@ describe('@ast-decorators/transform-accessor', () => {
       await compare('default', commonOptions);
     });
 
-    it('compiles for decorator on private property', async () => {
+    it('compiles for private property', async () => {
       await compare('private-property', commonOptions);
     });
 
-    it('compiles for decorator on property with assignment', async () => {
+    it('compiles for property with assignment', async () => {
       await compare('property-assigning', commonOptions);
     });
 
-    it('compiles for decorator on computed property', async () => {
+    it('compiles for computed property', async () => {
       await compare('computed-property', commonOptions);
     });
 
-    it('compiles for decorator on static property', async () => {
+    it('compiles for on static property', async () => {
       await compare('static-property', commonOptions);
     });
 

--- a/packages/utils/src/createPropertyByPrivacy.ts
+++ b/packages/utils/src/createPropertyByPrivacy.ts
@@ -5,18 +5,23 @@ import {
   Class,
   ClassBody,
   classPrivateProperty,
+  ClassProperty,
   classProperty,
-  Expression,
   privateName,
 } from '@babel/types';
 
 const createSymbolAssignment = template.statement(`const VAR = Symbol()`);
 
+export type PropertyOptions = Readonly<{
+  static?: boolean;
+  value?: ClassProperty['value'];
+}>;
+
 const createPropertyByPrivacy = (
   privacy: PrivacyType,
   name: string | undefined,
-  value: Expression | null,
   klass: NodePath<Class>,
+  {static: _static, value}: PropertyOptions = {},
 ): ClassMemberProperty => {
   switch (privacy) {
     case 'hard': {
@@ -24,7 +29,12 @@ const createPropertyByPrivacy = (
       const id = classBody.scope.generateUidIdentifier(name);
       const privateId = privateName(id);
 
-      return classPrivateProperty(privateId, value);
+      const prop = classPrivateProperty(privateId, value, null);
+
+      // @ts-ignore
+      prop.static = _static;
+
+      return prop;
     }
     case 'soft': {
       const id = klass.parentPath.scope.generateUidIdentifier(name);

--- a/packages/utils/tests/__snapshots__/createPropertyByPrivacy.ts.snap
+++ b/packages/utils/tests/__snapshots__/createPropertyByPrivacy.ts.snap
@@ -19,3 +19,9 @@ class Foo {
   [_bar] = \\"baz\\";
 }"
 `;
+
+exports[`@ast-decorators/utils createPropertyByPrivacy creates static property 1`] = `
+"class Foo {
+  static #_bar = \\"baz\\";
+}"
+`;

--- a/packages/utils/tests/createPropertyByPrivacy.ts
+++ b/packages/utils/tests/createPropertyByPrivacy.ts
@@ -16,5 +16,9 @@ describe('@ast-decorators/utils', () => {
     it('creates property when compiles with none privacy option', async () => {
       await compare('none');
     });
+
+    it('creates static property', async () => {
+      await compare('static');
+    });
   });
 });

--- a/packages/utils/tests/fixtures/createPropertyByPrivacy/plugin.ts
+++ b/packages/utils/tests/fixtures/createPropertyByPrivacy/plugin.ts
@@ -11,6 +11,7 @@ import createPropertyByPrivacy from '../../../src/createPropertyByPrivacy';
 
 export type BabelPluginTestOptions = {
   privacy: PrivacyType;
+  static: boolean;
 };
 
 const babelPluginTest = (): object => ({
@@ -20,6 +21,7 @@ const babelPluginTest = (): object => ({
       {opts}: PluginPass<BabelPluginTestOptions>,
     ) {
       const privacy = opts?.privacy ?? 'hard';
+      const _static = opts?.static ?? false;
       const klassBody = klass.get('body') as NodePath<ClassBody>;
       const [member] = klassBody.get('body') as readonly NodePath<
         ClassProperty
@@ -28,8 +30,8 @@ const babelPluginTest = (): object => ({
       const storage = createPropertyByPrivacy(
         privacy,
         (member.node.key as Identifier).name,
-        stringLiteral('baz'),
         klass,
+        {static: _static, value: stringLiteral('baz')},
       );
 
       klassBody.unshiftContainer('body', [storage]);

--- a/packages/utils/tests/fixtures/createPropertyByPrivacy/static/input.ts
+++ b/packages/utils/tests/fixtures/createPropertyByPrivacy/static/input.ts
@@ -1,0 +1,4 @@
+// @ts-ignore
+class Foo {
+  public bar?: string;
+}

--- a/packages/utils/tests/fixtures/createPropertyByPrivacy/static/options.ts
+++ b/packages/utils/tests/fixtures/createPropertyByPrivacy/static/options.ts
@@ -1,0 +1,8 @@
+export default {
+  comments: false,
+  presets: [require('@babel/preset-typescript')],
+  plugins: [
+    [require('../plugin'), {static: true}],
+    require('@babel/plugin-syntax-class-properties'),
+  ],
+};


### PR DESCRIPTION
This PR introduces static accessor transformation and resolves #15. Now you can apply a decorator to a static property and get static decorators in the output.

**input.js**

```js
class Foo {
  @accessor() static bar;
}
```

**output.js**

```js
class Foo {
  static #_bar;

  static get bar() {
    return this.#_bar;
  }

  static set bar(_value) {
    this.#_bar = _value;
  }
}
```

## Options

### useClassNameForStatic

```json
{
  "plugins": [
    [
      "@ast-decorators/core",
      {
        "transformers": [
          [
            "@ast-decorators/transform-accessor",
            {
              "useClassNameForStatic": false
            }
          ]
        ]
      }
    ]
  ]
}
```

You can use `useClassNameForStatic` option to avoid using `this` to address the generated private variable. If you enable this option, you will get the following output for the previous example.

**output.js**

```js
class Foo {
  static #_bar;

  static get bar() {
    return Foo.#_bar;
  }

  static set bar(_value) {
    Foo.#_bar = _value;
  }
}
```

Though, if the class is unnamed (e.g., if the class expression is used) `this` will be used anyway.

**output.js**

```js
const Foo = class {
  static #_bar;

  static get bar() {
    return this.#_bar;
  }

  static set bar(_value) {
    this.#_bar = _value;
  }
};
```
