### PR TITLE
Add wrap decorator

### DIFF
--- a/packages/transform-accessor/src/getter.ts
+++ b/packages/transform-accessor/src/getter.ts
@@ -1,4 +1,5 @@
 import type {ASTCallableDecorator} from '@ast-decorators/utils/lib/common';
+import hoistParameterFunction from '@ast-decorators/utils/lib/hoistParameterFunction';
 import type {NodePath} from '@babel/traverse';
 import {
   assignmentExpression,
@@ -13,9 +14,9 @@ import {
   FunctionDeclaration,
   identifier,
   Identifier,
-  isClassPrivateProperty,
   isIdentifier,
   isMethod,
+  isPrivate,
   memberExpression,
   NumericLiteral,
   PrivateName,
@@ -32,7 +33,6 @@ import {
   AccessorInterceptorNode,
   AccessorMethodCreator,
   ownerNode,
-  prepareInterceptor,
   TransformAccessorOptions,
 } from './utils';
 
@@ -100,7 +100,7 @@ export const getter: AccessorMethodCreator = (
   const declarations: Array<FunctionDeclaration | VariableDeclaration> = [];
 
   const [interceptorId, interceptorDeclaration] = interceptor
-    ? prepareInterceptor(klass, interceptor.node, 'get')
+    ? hoistParameterFunction(interceptor.node, 'get', klass.parentPath.scope)
     : [];
 
   if (interceptorDeclaration) {
@@ -140,11 +140,11 @@ export const getter: AccessorMethodCreator = (
     newBody = blockStatement([returnStatement(result)]);
   }
 
-  // @ts-expect-error: "computed" do not exist on the ClassMemberProperty (it
+  // @ts-expect-error: "computed" do not exist on the ClassPrivateProperty (it
   // will simply be undefined) and "static" is not listed in d.ts
   const {computed, key, static: _static} = member.node;
 
-  const method = isClassPrivateProperty(member)
+  const method = isPrivate(member)
     ? classPrivateMethod('get', key as PrivateName, [], newBody, _static)
     : classMethod(
         'get',

--- a/packages/transform-accessor/src/getter.ts
+++ b/packages/transform-accessor/src/getter.ts
@@ -1,5 +1,5 @@
 import type {ASTCallableDecorator} from '@ast-decorators/utils/lib/common';
-import hoistParameterFunction from '@ast-decorators/utils/lib/hoistParameterFunction';
+import hoistFunctionParameter from '@ast-decorators/utils/lib/hoistFunctionParameter';
 import type {NodePath} from '@babel/traverse';
 import {
   assignmentExpression,
@@ -100,7 +100,7 @@ export const getter: AccessorMethodCreator = (
   const declarations: Array<FunctionDeclaration | VariableDeclaration> = [];
 
   const [interceptorId, interceptorDeclaration] = interceptor
-    ? hoistParameterFunction(interceptor.node, 'get', klass.parentPath.scope)
+    ? hoistFunctionParameter(interceptor.node, 'get', klass.parentPath.scope)
     : [];
 
   if (interceptorDeclaration) {

--- a/packages/transform-accessor/src/setter.ts
+++ b/packages/transform-accessor/src/setter.ts
@@ -2,7 +2,7 @@ import type {
   ASTCallableDecorator,
   ClassMemberMethod,
 } from '@ast-decorators/utils/lib/common';
-import hoistParameterFunction from '@ast-decorators/utils/lib/hoistParameterFunction';
+import hoistFunctionParameter from '@ast-decorators/utils/lib/hoistFunctionParameter';
 import type {NodePath} from '@babel/traverse';
 import {
   ArrayPattern,
@@ -68,7 +68,7 @@ export const setter: AccessorMethodCreator = (
   const declarations: Array<FunctionDeclaration | VariableDeclaration> = [];
 
   const [interceptorId, interceptorDeclaration] = interceptor
-    ? hoistParameterFunction(interceptor.node, 'set', klass.parentPath.scope)
+    ? hoistFunctionParameter(interceptor.node, 'set', klass.parentPath.scope)
     : [];
 
   if (interceptorDeclaration) {

--- a/packages/transform-accessor/src/utils.ts
+++ b/packages/transform-accessor/src/utils.ts
@@ -1,14 +1,13 @@
 import ASTDecoratorsError from '@ast-decorators/utils/lib/ASTDecoratorsError';
 import type {SuitabilityFactors} from '@ast-decorators/utils/lib/checkSuitability';
 import type {
+  ClassMember,
   ClassMemberMethod,
   ClassMemberProperty,
   PrivacyType,
 } from '@ast-decorators/utils/lib/common';
 import createPropertyByPrivacy from '@ast-decorators/utils/lib/createPropertyByPrivacy';
 import getMemberName from '@ast-decorators/utils/lib/getMemberName';
-import type {ClassMember} from '@ast-decorators/utils/src/common';
-import template from '@babel/template';
 import type {NodePath, Scope} from '@babel/traverse';
 import {
   ArrayPattern,
@@ -17,7 +16,6 @@ import {
   cloneNode,
   Decorator,
   FunctionDeclaration,
-  functionDeclaration,
   FunctionExpression,
   Identifier,
   isArrayPattern,
@@ -120,46 +118,11 @@ export const createStorage = (
     value: member.value,
   });
 
-const declarator = template(`const VAR = FUNCTION`);
-
 export const ownerNode = (
   klass: Class,
   useClassName: boolean,
 ): Identifier | ThisExpression =>
   useClassName && klass.id ? cloneNode(klass.id) : thisExpression();
-
-export const prepareInterceptor = (
-  klass: NodePath<Class>,
-  interceptor: AccessorInterceptorNode,
-  type: 'get' | 'set',
-): readonly [
-  Identifier | MemberExpression,
-  FunctionDeclaration | VariableDeclaration | null,
-] => {
-  const isArrow = isArrowFunctionExpression(interceptor);
-  const isRegular = isFunctionExpression(interceptor);
-
-  const interceptorId =
-    isArrow || isRegular
-      ? klass.parentPath.scope.generateUidIdentifier(type)
-      : (interceptor as Identifier | MemberExpression);
-
-  return [
-    interceptorId,
-    isArrow
-      ? (declarator({
-          FUNCTION: interceptor,
-          VAR: interceptorId as Identifier,
-        }) as VariableDeclaration)
-      : isRegular
-      ? functionDeclaration(
-          interceptorId as Identifier,
-          (interceptor as FunctionExpression).params,
-          (interceptor as FunctionExpression).body,
-        )
-      : null,
-  ];
-};
 
 export const unifyValueParameter = (
   scope: Scope,

--- a/packages/transform-bind/src/bind.ts
+++ b/packages/transform-bind/src/bind.ts
@@ -3,14 +3,16 @@ import type {
   ClassMember,
   ClassMemberMethod,
 } from '@ast-decorators/utils/lib/common';
+import {
+  classPrivateMethod,
+  classPrivateProperty,
+} from '@ast-decorators/utils/lib/babelFixes';
 import type {Scope} from '@babel/traverse';
 import {
   CallExpression,
   callExpression,
   ClassMethod,
-  classPrivateMethod,
   ClassPrivateMethod,
-  classPrivateProperty,
   classProperty,
   Expression,
   identifier,
@@ -51,24 +53,23 @@ const bindPrivate = (method: ClassPrivateMethod, scope: Scope): BoundNodes => {
   const replacementNode = classPrivateProperty(
     key,
     createBindingExpression(replacementKey),
+    null,
+    null,
+    _static,
   );
 
-  // @ts-expect-error: "static" is not listed in d.ts
-  replacementNode.static = _static;
-
-  const replacementMethod = classPrivateMethod(
+  const replacementMethodDeclaration = classPrivateMethod(
     'method',
     replacementKey,
     params,
     body,
+    decorators,
     _static,
+    generator,
+    async,
   );
 
-  replacementMethod.async = async;
-  replacementMethod.generator = generator;
-  replacementMethod.decorators = decorators;
-
-  return [replacementNode, replacementMethod];
+  return [replacementNode, replacementMethodDeclaration];
 };
 
 const bindRegular = (method: ClassMethod): BoundNodes => {

--- a/packages/transform-bind/tests/bind.ts
+++ b/packages/transform-bind/tests/bind.ts
@@ -1,4 +1,5 @@
 import {transformFile as _transformFile} from '../../../utils/testing';
+import {bind} from '../src';
 import commonOptions from './fixtures/options';
 
 const transformFile = async (
@@ -69,6 +70,15 @@ describe('@ast-decorators/transform-bind', () => {
         transformFile('failure-not-method-accessor', commonOptions),
       ).rejects.toThrowError(
         'Applying @bind decorator to something other than method is not allowed',
+      );
+    });
+
+    it('fails if transformer is not plugged in', () => {
+      // @ts-expect-error: Here the runtime replacement used. It does not
+      // require arguments
+      expect(() => bind()()).toThrowError(
+        "Decorator @bind won't work because @ast-decorators/transform-bind/lib/transformer" +
+          'is not plugged in. You have to add it to your Babel config',
       );
     });
   });

--- a/packages/transform-bind/tests/bindAll.ts
+++ b/packages/transform-bind/tests/bindAll.ts
@@ -1,4 +1,5 @@
 import {transformFile as _transformFile} from '../../../utils/testing';
+import {bindAll} from '../src';
 import commonOptions from './fixtures/options';
 
 const transformFile = async (
@@ -19,6 +20,15 @@ describe('@ast-decorators/transform-bind', () => {
         transformFile('failure-no-class', commonOptions),
       ).rejects.toThrowError(
         'Applying @bindAll decorator to something other than class is not allowed',
+      );
+    });
+
+    it('fails if transformer is not plugged in', () => {
+      // @ts-expect-error: Here the runtime replacement used. It does not
+      // require arguments
+      expect(() => bindAll()()).toThrowError(
+        "Decorator @bindAll won't work because @ast-decorators/transform-bind/lib/transformer" +
+          'is not plugged in. You have to add it to your Babel config',
       );
     });
   });

--- a/packages/transform-wrap/package-lock.json
+++ b/packages/transform-wrap/package-lock.json
@@ -1,0 +1,228 @@
+{
+	"name": "@ast-decorators/transform-wrap",
+	"version": "0.1.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+			"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+			"requires": {
+				"@babel/highlight": "^7.8.3"
+			}
+		},
+		"@babel/generator": {
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
+			"integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
+			"requires": {
+				"@babel/types": "^7.9.6",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.13",
+				"source-map": "^0.5.0"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+			"integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.8.3",
+				"@babel/template": "^7.8.3",
+				"@babel/types": "^7.9.5"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+			"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+			"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+			"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
+		},
+		"@babel/highlight": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+			"integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.9.0",
+				"chalk": "^2.0.0",
+				"js-tokens": "^4.0.0"
+			}
+		},
+		"@babel/parser": {
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
+			"integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q=="
+		},
+		"@babel/template": {
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+			"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+			"requires": {
+				"@babel/code-frame": "^7.8.3",
+				"@babel/parser": "^7.8.6",
+				"@babel/types": "^7.8.6"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
+			"integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
+			"requires": {
+				"@babel/code-frame": "^7.8.3",
+				"@babel/generator": "^7.9.6",
+				"@babel/helper-function-name": "^7.9.5",
+				"@babel/helper-split-export-declaration": "^7.8.3",
+				"@babel/parser": "^7.9.6",
+				"@babel/types": "^7.9.6",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.13"
+			}
+		},
+		"@babel/types": {
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+			"integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.9.5",
+				"lodash": "^4.17.13",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"debug": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"requires": {
+				"ms": "^2.1.1"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+		},
+		"lodash": {
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+		}
+	}
+}

--- a/packages/transform-wrap/package.json
+++ b/packages/transform-wrap/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@ast-decorators/transform-wrap",
+  "version": "0.1.0",
+  "description": "Wraps method with a received function",
+  "main": "lib/index.js",
+  "scripts": {
+    "build:js": "babel src -d lib -x .ts --config-file ../../babel.config.json --ignore \"src/**/*.d.ts\" --copy-files",
+    "build:dts": "tsc -p tsconfig.build.json --emitDeclarationOnly",
+    "build:remove": "rimraf lib",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@ast-decorators/utils": "^0.1.0",
+    "@babel/traverse": "^7.9.6",
+    "@babel/types": "^7.9.6",
+    "minimatch": "^3.0.4"
+  },
+  "devDependencies": {
+    "@ast-decorators/core": "^0.1.0"
+  }
+}

--- a/packages/transform-wrap/src/index.ts
+++ b/packages/transform-wrap/src/index.ts
@@ -1,0 +1,11 @@
+import replaceDecorator from '@ast-decorators/utils/lib/replaceDecorator';
+
+const transformerName = '@ast-decorators/transform-wrap';
+
+export const wrap: <
+  A extends any[],
+  F extends (this: object | undefined, ...args: A) => any
+>(
+  wrapper: (fn: F, ...args: A) => F,
+  ...args: A
+) => PropertyDecorator = replaceDecorator('wrap', transformerName) as any;

--- a/packages/transform-wrap/src/transformer.ts
+++ b/packages/transform-wrap/src/transformer.ts
@@ -1,0 +1,25 @@
+import type {
+  ASTDecoratorDetector,
+  ASTDecoratorTransformer,
+} from '@ast-decorators/utils/lib/common';
+import type {NodePath} from '@babel/core';
+import minimatch from 'minimatch';
+import {wrapTransformer} from './wrap';
+import type {AllowedWrappers, TransformWrapOptions} from './utils';
+
+export const TRANSFORMER_NAME = '@ast-decorators/transform-wrap';
+
+const detector = (
+  decoratorName: string,
+  transformerName: string = TRANSFORMER_NAME,
+): ASTDecoratorDetector => (name: string, path: string): boolean =>
+  name === decoratorName && minimatch(path, transformerName);
+
+const transformer: ASTDecoratorTransformer<
+  [NodePath<AllowedWrappers>],
+  TransformWrapOptions
+> = (_, {transformerPath}: TransformWrapOptions = {}) => [
+  [wrapTransformer, detector('wrap', transformerPath)] as const,
+];
+
+export default transformer;

--- a/packages/transform-wrap/src/utils.ts
+++ b/packages/transform-wrap/src/utils.ts
@@ -1,5 +1,5 @@
 import ASTDecoratorsError from '@ast-decorators/utils/lib/ASTDecoratorsError';
-import type {ClassMember, PrivacyType} from '@ast-decorators/utils/src/common';
+import type {ClassMember, PrivacyType} from '@ast-decorators/utils/lib/common';
 import {
   ArrowFunctionExpression,
   FunctionExpression,

--- a/packages/transform-wrap/src/utils.ts
+++ b/packages/transform-wrap/src/utils.ts
@@ -1,0 +1,48 @@
+import ASTDecoratorsError from '@ast-decorators/utils/lib/ASTDecoratorsError';
+import type {ClassMember, PrivacyType} from '@ast-decorators/utils/src/common';
+import {
+  ArrowFunctionExpression,
+  FunctionExpression,
+  Identifier,
+  isArrowFunctionExpression,
+  isClassPrivateProperty,
+  isClassProperty,
+  isFunctionExpression,
+  isIdentifier,
+  isMemberExpression,
+  isMethod,
+  MemberExpression,
+} from '@babel/types';
+
+export type TransformWrapOptions = Readonly<{
+  privacy?: PrivacyType;
+  transformerPath?: string;
+}>;
+
+const isClassPropertyWithFunctionAssigned = (member: ClassMember) =>
+  (isClassProperty(member) || isClassPrivateProperty(member)) &&
+  member.value &&
+  (isFunctionExpression(member.value) ||
+    isArrowFunctionExpression(member.value) ||
+    isIdentifier(member.value) ||
+    isMemberExpression(member.value));
+
+export type AllowedWrappers =
+  | FunctionExpression
+  | ArrowFunctionExpression
+  | Identifier
+  | MemberExpression;
+
+export const assertWrap = (member?: ClassMember): void => {
+  if (!member) {
+    throw new ASTDecoratorsError(
+      '@wrap: Allowed for methods and properties only',
+    );
+  }
+
+  if (!isMethod(member) && !isClassPropertyWithFunctionAssigned(member)) {
+    throw new ASTDecoratorsError(
+      '@wrap can only be applied to class methods or properties with function assigned',
+    );
+  }
+};

--- a/packages/transform-wrap/src/wrap.ts
+++ b/packages/transform-wrap/src/wrap.ts
@@ -8,7 +8,7 @@ import type {
 import createPropertyByPrivacy from '@ast-decorators/utils/lib/createPropertyByPrivacy';
 import getMemberName from '@ast-decorators/utils/lib/getMemberName';
 import hoistFunctionParameter from '@ast-decorators/utils/lib/hoistFunctionParameter';
-import {cloneClassMember} from '@ast-decorators/utils/lib/babelFixes';
+import {cloneNode} from '@ast-decorators/utils/lib/babelFixes';
 import template from '@babel/template';
 import type {NodePath} from '@babel/traverse';
 import {
@@ -89,7 +89,7 @@ const addNewWrapperToStaticMirror = (
   wrapperId: Identifier | MemberExpression,
   args: CallExpression['arguments'],
 ): StaticMirror => {
-  const newDeclaration = cloneClassMember(declaration);
+  const newDeclaration = cloneNode(declaration);
 
   newDeclaration.value = callExpression(wrapperId, [
     declaration.value!,
@@ -119,7 +119,7 @@ const prepareMethodReplacement = (
     ),
   ]);
 
-  const method = cloneClassMember(member);
+  const method = cloneNode(member);
   method.params = params;
   method.body = body;
   method.generator = false;
@@ -134,7 +134,7 @@ const preparePropertyReplacement = (
 ): ClassMemberProperty => {
   const wrappedValue = callExpression(wrapperId, [member.value!, ...args]);
 
-  const property = cloneClassMember(member);
+  const property = cloneNode(member);
   property.value = wrappedValue;
 
   return property;

--- a/packages/transform-wrap/src/wrap.ts
+++ b/packages/transform-wrap/src/wrap.ts
@@ -7,7 +7,7 @@ import type {
 } from '@ast-decorators/utils/lib/common';
 import createPropertyByPrivacy from '@ast-decorators/utils/lib/createPropertyByPrivacy';
 import getMemberName from '@ast-decorators/utils/lib/getMemberName';
-import hoistParameterFunction from '@ast-decorators/utils/lib/hoistParameterFunction';
+import hoistFunctionParameter from '@ast-decorators/utils/lib/hoistFunctionParameter';
 import {cloneClassMember} from '@ast-decorators/utils/lib/babelFixes';
 import template from '@babel/template';
 import type {NodePath} from '@babel/traverse';
@@ -152,7 +152,7 @@ export const wrap = (
   ClassMemberProperty?,
   (FunctionDeclaration | VariableDeclaration)?,
 ] => {
-  const [wrapperId, wrapperFunctionDeclaration] = hoistParameterFunction(
+  const [wrapperId, wrapperFunctionDeclaration] = hoistFunctionParameter(
     wrapper,
     'wrap',
     klass.parentPath.scope,

--- a/packages/transform-wrap/src/wrap.ts
+++ b/packages/transform-wrap/src/wrap.ts
@@ -1,0 +1,217 @@
+import type {
+  ASTCallableDecorator,
+  ClassMember,
+  ClassMemberMethod,
+  ClassMemberProperty,
+  PrivacyType,
+} from '@ast-decorators/utils/lib/common';
+import createPropertyByPrivacy from '@ast-decorators/utils/lib/createPropertyByPrivacy';
+import getMemberName from '@ast-decorators/utils/lib/getMemberName';
+import hoistParameterFunction from '@ast-decorators/utils/lib/hoistParameterFunction';
+import {cloneClassMember} from '@ast-decorators/utils/lib/babelFixes';
+import template from '@babel/template';
+import type {NodePath} from '@babel/traverse';
+import {
+  ArgumentPlaceholder,
+  blockStatement,
+  CallExpression,
+  callExpression,
+  Class,
+  Expression,
+  FunctionDeclaration,
+  functionExpression,
+  identifier,
+  Identifier,
+  isClassMethod,
+  isClassPrivateMethod,
+  JSXNamespacedName,
+  MemberExpression,
+  memberExpression,
+  PrivateName,
+  restElement,
+  returnStatement,
+  SpreadElement,
+  thisExpression,
+  VariableDeclaration,
+} from '@babel/types';
+import {AllowedWrappers, assertWrap, TransformWrapOptions} from './utils';
+
+const STATIC_MIRROR_KEY = 'key:wrapper-static-mirror';
+
+type StaticMirror = readonly [Identifier | PrivateName, ClassMemberProperty];
+
+const findExistingReplacer = (
+  klass: NodePath<Class>,
+  member: NodePath<ClassMember>,
+): NodePath<ClassMemberProperty> | undefined => {
+  const replacerId = member.getData(STATIC_MIRROR_KEY);
+
+  return replacerId
+    ? ((klass.get('body.body') as ReadonlyArray<NodePath<ClassMember>>).find(
+        ({node}: NodePath<ClassMember>) => getMemberName(node) === replacerId,
+      ) as NodePath<ClassMemberProperty>)
+    : undefined;
+};
+
+const prepareStaticMirror = (
+  klass: NodePath<Class>,
+  member: ClassMemberMethod,
+  wrapperId: Identifier | MemberExpression,
+  args: CallExpression['arguments'],
+  privacy: PrivacyType = 'hard',
+): StaticMirror => {
+  const {async, body, generator, params} = member;
+
+  const declaration = createPropertyByPrivacy(
+    privacy,
+    getMemberName(member),
+    klass,
+    {
+      static: true,
+      value: callExpression(wrapperId, [
+        functionExpression(
+          identifier(getMemberName(member)?.toString() ?? 'wrap'),
+          params,
+          body,
+          generator,
+          async,
+        ),
+        ...args,
+      ]),
+    },
+  );
+
+  return [declaration.key as Identifier | PrivateName, declaration];
+};
+
+const addNewWrapperToStaticMirror = (
+  declaration: ClassMemberProperty,
+  wrapperId: Identifier | MemberExpression,
+  args: CallExpression['arguments'],
+): StaticMirror => {
+  const newDeclaration = cloneClassMember(declaration);
+
+  newDeclaration.value = callExpression(wrapperId, [
+    declaration.value!,
+    ...args,
+  ]);
+
+  return [declaration.key as Identifier | PrivateName, newDeclaration];
+};
+
+const constructorProperty = template.expression('this.constructor.KEY');
+
+const prepareMethodReplacement = (
+  member: ClassMemberMethod,
+  hoistedMethodId: Identifier | PrivateName,
+): ClassMemberMethod => {
+  const methodArgs = identifier('args');
+  const params = [restElement(methodArgs)];
+  const body = blockStatement([
+    returnStatement(
+      callExpression(
+        memberExpression(
+          constructorProperty({KEY: hoistedMethodId}),
+          identifier('apply'),
+        ),
+        [thisExpression(), methodArgs],
+      ),
+    ),
+  ]);
+
+  const method = cloneClassMember(member);
+  method.params = params;
+  method.body = body;
+  method.generator = false;
+
+  return method;
+};
+
+const preparePropertyReplacement = (
+  member: ClassMemberProperty,
+  wrapperId: Identifier | MemberExpression,
+  args: CallExpression['arguments'],
+): ClassMemberProperty => {
+  const wrappedValue = callExpression(wrapperId, [member.value!, ...args]);
+
+  const property = cloneClassMember(member);
+  property.value = wrappedValue;
+
+  return property;
+};
+
+export const wrap = (
+  klass: NodePath<Class>,
+  member: NodePath<ClassMember>,
+  wrapper: AllowedWrappers,
+  args: CallExpression['arguments'],
+  existingReplacer?: ClassMemberProperty,
+  privacy?: PrivacyType,
+): readonly [
+  ClassMember,
+  ClassMemberProperty?,
+  (FunctionDeclaration | VariableDeclaration)?,
+] => {
+  const [wrapperId, wrapperFunctionDeclaration] = hoistParameterFunction(
+    wrapper,
+    'wrap',
+    klass.parentPath.scope,
+  );
+
+  if (isClassMethod(member.node) || isClassPrivateMethod(member.node)) {
+    const [methodId, methodDeclaration] = existingReplacer
+      ? addNewWrapperToStaticMirror(existingReplacer, wrapperId, args)
+      : prepareStaticMirror(klass, member.node, wrapperId, args, privacy);
+
+    return [
+      prepareMethodReplacement(member.node, methodId),
+      methodDeclaration,
+      wrapperFunctionDeclaration,
+    ];
+  }
+
+  const property = preparePropertyReplacement(member.node, wrapperId, args);
+
+  return [property, undefined, wrapperFunctionDeclaration];
+};
+
+export const wrapTransformer: ASTCallableDecorator<
+  [
+    NodePath<AllowedWrappers>,
+    ...ReadonlyArray<
+      NodePath<
+        Expression | SpreadElement | JSXNamespacedName | ArgumentPlaceholder
+      >
+    >
+  ],
+  TransformWrapOptions
+> = (wrapper, ...args) => ({klass, member}, options) => {
+  assertWrap(member?.node);
+
+  const existingReplacer = findExistingReplacer(klass, member!);
+
+  const [replacement, replacerMethod, wrapperFunctionDeclaration] = wrap(
+    klass,
+    member!,
+    wrapper.node,
+    args.map(({node}) => node),
+    existingReplacer?.node,
+    options?.privacy,
+  );
+
+  if (wrapperFunctionDeclaration) {
+    klass.insertBefore(wrapperFunctionDeclaration);
+  }
+
+  if (replacerMethod) {
+    if (existingReplacer) {
+      existingReplacer.replaceWith(replacerMethod);
+    } else {
+      member!.insertBefore(replacerMethod);
+    }
+
+    member!.setData(STATIC_MIRROR_KEY, getMemberName(replacerMethod));
+  }
+
+  member!.replaceWith(replacement);
+};

--- a/packages/transform-wrap/tests/__snapshots__/wrap.ts.snap
+++ b/packages/transform-wrap/tests/__snapshots__/wrap.ts.snap
@@ -1,0 +1,204 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@ast-decorators/transform-wrap @wrap method compiles for a generator method 1`] = `
+"import { wrapper } from './bar';
+
+class Foo {
+  static #_bar = wrapper(function* bar(num) {
+    return num * num;
+  });
+
+  bar(...args) {
+    return this.constructor.#_bar.apply(this, args);
+  }
+
+}"
+`;
+
+exports[`@ast-decorators/transform-wrap @wrap method compiles for a private generator method 1`] = `
+"import { wrapper } from './bar';
+
+class Foo {
+  static #_bar = wrapper(function* bar(num) {
+    return num * num;
+  });
+
+  #bar(...args) {
+    return this.constructor.#_bar.apply(this, args);
+  }
+
+}"
+`;
+
+exports[`@ast-decorators/transform-wrap @wrap method compiles for a private method 1`] = `
+"import { wrapper } from './bar';
+
+class Foo {
+  static #_bar = wrapper(function bar(num) {
+    return num * num;
+  });
+
+  #bar(...args) {
+    return this.constructor.#_bar.apply(this, args);
+  }
+
+}"
+`;
+
+exports[`@ast-decorators/transform-wrap @wrap property compiles for a private property 1`] = `
+"import { wrapper } from './wrapper';
+
+class Foo {
+  #bar = wrapper(num => {
+    return num * num;
+  });
+}"
+`;
+
+exports[`@ast-decorators/transform-wrap @wrap property compiles for a property defined as a regular function 1`] = `
+"import { wrapper } from './wrapper';
+
+class Foo {
+  bar = wrapper(function (num) {
+    return num * num;
+  });
+}"
+`;
+
+exports[`@ast-decorators/transform-wrap @wrap property compiles for a property defined as an arrow function 1`] = `
+"import { wrapper } from './wrapper';
+
+class Foo {
+  bar = wrapper(num => {
+    return num * num;
+  });
+}"
+`;
+
+exports[`@ast-decorators/transform-wrap @wrap wrapper types compiles for a method with inline arrow wrapper 1`] = `
+"const _wrap = fn => function (...args) {
+  const result = fn.apply(this, args);
+  console.log(result);
+  return result;
+};
+
+class Foo {
+  static #_bar = _wrap(function bar(num) {
+    return num * num;
+  });
+
+  bar(...args) {
+    return this.constructor.#_bar.apply(this, args);
+  }
+
+}"
+`;
+
+exports[`@ast-decorators/transform-wrap @wrap wrapper types compiles for a method with inline regular wrapper 1`] = `
+"function _wrap(fn) {
+  return function (...args) {
+    const result = fn.apply(this, args);
+    console.log(result);
+    return result;
+  };
+}
+
+class Foo {
+  static #_bar = _wrap(function bar(num) {
+    return num * num;
+  });
+
+  bar(...args) {
+    return this.constructor.#_bar.apply(this, args);
+  }
+
+}"
+`;
+
+exports[`@ast-decorators/transform-wrap @wrap wrapper types compiles for a method with multiple wrappers 1`] = `
+"import { wrap } from '../../../../src';
+import { dec1 } from './dec1';
+import { dec2 } from './dec2';
+import { dec3 } from './dec2';
+
+class Foo {
+  static #_bar = dec3(dec2(dec1(function bar(num) {
+    return num * num;
+  }, 1), 2, 1), 3, 2, 1);
+
+  bar(...args) {
+    return this.constructor.#_bar.apply(this, args);
+  }
+
+}"
+`;
+
+exports[`@ast-decorators/transform-wrap @wrap wrapper types compiles for a method with wrapper declared in the same file as a regular function 1`] = `
+"function wrapper(fn) {
+  return function (...args) {
+    const result = fn.apply(this, args);
+    console.log(result);
+    return result;
+  };
+}
+
+class Foo {
+  static #_bar = wrapper(function bar(num) {
+    return num * num;
+  });
+
+  bar(...args) {
+    return this.constructor.#_bar.apply(this, args);
+  }
+
+}"
+`;
+
+exports[`@ast-decorators/transform-wrap @wrap wrapper types compiles for a method with wrapper declared in the same file as an arrow function 1`] = `
+"const wrapper = fn => function (...args) {
+  const result = fn.apply(this, args);
+  console.log(result);
+  return result;
+};
+
+class Foo {
+  static #_bar = wrapper(function bar(num) {
+    return num * num;
+  });
+
+  bar(...args) {
+    return this.constructor.#_bar.apply(this, args);
+  }
+
+}"
+`;
+
+exports[`@ast-decorators/transform-wrap @wrap wrapper types compiles for a method with wrapper imported from an external file 1`] = `
+"import { wrapper } from './bar';
+
+class Foo {
+  static #_bar = wrapper(function bar(num) {
+    return num * num;
+  });
+
+  bar(...args) {
+    return this.constructor.#_bar.apply(this, args);
+  }
+
+}"
+`;
+
+exports[`@ast-decorators/transform-wrap @wrap wrapper types sends arguments to a wrapper function 1`] = `
+"import { wrapper } from './wrapper';
+
+class Foo {
+  static #_bar = wrapper(function bar(num) {
+    return num * num;
+  }, 'foo', 'bar', 42);
+
+  bar(...args) {
+    return this.constructor.#_bar.apply(this, args);
+  }
+
+}"
+`;

--- a/packages/transform-wrap/tests/fixtures/options.ts
+++ b/packages/transform-wrap/tests/fixtures/options.ts
@@ -1,0 +1,21 @@
+export default {
+  comments: false,
+  presets: [require('@babel/preset-typescript')],
+  plugins: [
+    [
+      require('@ast-decorators/core'),
+      {
+        transformers: [
+          [
+            require('../../src/transformer'),
+            {
+              transformerPath: '**/transform-wrap/src',
+            },
+          ],
+        ],
+      },
+    ],
+    [require('@babel/plugin-syntax-decorators'), {legacy: true}],
+    require('@babel/plugin-syntax-class-properties'),
+  ],
+};

--- a/packages/transform-wrap/tests/fixtures/wrap/method-generator/input.ts
+++ b/packages/transform-wrap/tests/fixtures/wrap/method-generator/input.ts
@@ -1,0 +1,13 @@
+// @ts-ignore
+import {wrap} from '../../../../src';
+// @ts-ignore
+import {wrapper} from './bar';
+
+// @ts-ignore
+class Foo {
+  // @ts-ignore
+  @wrap(wrapper)
+  public *bar(num: number) {
+    return num * num;
+  }
+}

--- a/packages/transform-wrap/tests/fixtures/wrap/method-private-generator/input.ts
+++ b/packages/transform-wrap/tests/fixtures/wrap/method-private-generator/input.ts
@@ -1,0 +1,14 @@
+// @ts-ignore
+import {wrap} from '../../../../src';
+// @ts-ignore
+import {wrapper} from './bar';
+
+// @ts-ignore
+class Foo {
+  // @ts-ignore
+  @wrap(wrapper)
+  // @ts-ignore
+  *#bar(num: number) {
+    return num * num;
+  }
+}

--- a/packages/transform-wrap/tests/fixtures/wrap/method-private/input.ts
+++ b/packages/transform-wrap/tests/fixtures/wrap/method-private/input.ts
@@ -1,0 +1,14 @@
+// @ts-ignore
+import {wrap} from '../../../../src';
+// @ts-ignore
+import {wrapper} from './bar';
+
+// @ts-ignore
+class Foo {
+  // @ts-ignore
+  @wrap(wrapper)
+  // @ts-ignore
+  #bar(num: number) {
+    return num * num;
+  }
+}

--- a/packages/transform-wrap/tests/fixtures/wrap/property-arrow/input.ts
+++ b/packages/transform-wrap/tests/fixtures/wrap/property-arrow/input.ts
@@ -1,0 +1,11 @@
+import {wrap} from '../../../../src';
+// @ts-ignore
+import {wrapper} from './wrapper';
+
+// @ts-ignore
+class Foo {
+  @wrap(wrapper)
+  public bar = (num: number) => {
+    return num * num;
+  }
+}

--- a/packages/transform-wrap/tests/fixtures/wrap/property-incorrect-value/input.ts
+++ b/packages/transform-wrap/tests/fixtures/wrap/property-incorrect-value/input.ts
@@ -1,0 +1,9 @@
+import {wrap} from '../../../../src';
+// @ts-ignore
+import {wrapper} from './wrapper';
+
+// @ts-ignore
+class Foo {
+  @wrap(wrapper)
+  public bar = 'baz';
+}

--- a/packages/transform-wrap/tests/fixtures/wrap/property-no-function/input.ts
+++ b/packages/transform-wrap/tests/fixtures/wrap/property-no-function/input.ts
@@ -1,0 +1,9 @@
+import {wrap} from '../../../../src';
+// @ts-ignore
+import {wrapper} from './wrapper';
+
+// @ts-ignore
+class Foo {
+  @wrap(wrapper)
+  public bar;
+}

--- a/packages/transform-wrap/tests/fixtures/wrap/property-private/input.ts
+++ b/packages/transform-wrap/tests/fixtures/wrap/property-private/input.ts
@@ -1,0 +1,14 @@
+// @ts-ignore
+import {wrap} from '../../../../src';
+// @ts-ignore
+import {wrapper} from './wrapper';
+
+// @ts-ignore
+class Foo {
+  // @ts-ignore
+  @wrap(wrapper)
+  // @ts-ignore
+  #bar = (num: number) => {
+    return num * num;
+  }
+}

--- a/packages/transform-wrap/tests/fixtures/wrap/property-regular/input.ts
+++ b/packages/transform-wrap/tests/fixtures/wrap/property-regular/input.ts
@@ -1,0 +1,11 @@
+import {wrap} from '../../../../src';
+// @ts-ignore
+import {wrapper} from './wrapper';
+
+// @ts-ignore
+class Foo {
+  @wrap(wrapper)
+  public bar = function (num: number): number {
+    return num * num;
+  };
+}

--- a/packages/transform-wrap/tests/fixtures/wrap/wrapper-args/input.ts
+++ b/packages/transform-wrap/tests/fixtures/wrap/wrapper-args/input.ts
@@ -1,0 +1,11 @@
+import {wrap} from '../../../../src';
+// @ts-ignore
+import {wrapper} from './wrapper';
+
+// @ts-ignore
+class Foo {
+  @wrap(wrapper, 'foo', 'bar', 42)
+  public bar(num: number) {
+    return num * num;
+  }
+}

--- a/packages/transform-wrap/tests/fixtures/wrap/wrapper-import-default/input.ts
+++ b/packages/transform-wrap/tests/fixtures/wrap/wrapper-import-default/input.ts
@@ -1,0 +1,11 @@
+import {wrap} from '../../../../src';
+// @ts-ignore
+import {wrapper} from './bar';
+
+// @ts-ignore
+class Foo {
+  @wrap(wrapper)
+  public bar(num: number) {
+    return num * num;
+  }
+}

--- a/packages/transform-wrap/tests/fixtures/wrap/wrapper-inline-arrow/input.ts
+++ b/packages/transform-wrap/tests/fixtures/wrap/wrapper-inline-arrow/input.ts
@@ -1,0 +1,14 @@
+import {wrap} from '../../../../src';
+
+// @ts-ignore
+class Foo {
+  @wrap(fn => function (...args) {
+    const result = fn.apply(this, args);
+    console.log(result);
+
+    return result;
+  })
+  public bar(num: number) {
+    return num * num;
+  }
+}

--- a/packages/transform-wrap/tests/fixtures/wrap/wrapper-inline-regular/input.ts
+++ b/packages/transform-wrap/tests/fixtures/wrap/wrapper-inline-regular/input.ts
@@ -1,0 +1,16 @@
+import {wrap} from '../../../../src';
+
+// @ts-ignore
+class Foo {
+  @wrap(function (this: Foo, fn) {
+    return function (...args) {
+      const result = fn.apply(this, args);
+      console.log(result);
+
+      return result;
+    };
+  })
+  public bar(num: number) {
+    return num * num;
+  }
+}

--- a/packages/transform-wrap/tests/fixtures/wrap/wrapper-multiple/input.ts
+++ b/packages/transform-wrap/tests/fixtures/wrap/wrapper-multiple/input.ts
@@ -1,0 +1,17 @@
+import {wrap} from '../../../../src';
+// @ts-ignore
+import {dec1} from './dec1';
+// @ts-ignore
+import {dec2} from './dec2';
+// @ts-ignore
+import {dec3} from './dec2';
+
+// @ts-ignore
+class Foo {
+  @wrap(dec3, 3, 2, 1)
+  @wrap(dec2, 2, 1)
+  @wrap(dec1, 1)
+  public bar(num: number) {
+    return num * num;
+  }
+}

--- a/packages/transform-wrap/tests/fixtures/wrap/wrapper-within-arrow/input.ts
+++ b/packages/transform-wrap/tests/fixtures/wrap/wrapper-within-arrow/input.ts
@@ -1,0 +1,17 @@
+import {wrap} from '../../../../src';
+
+const wrapper = (fn: Foo['bar']) =>
+  function (this: Foo, ...args: any[]) {
+    const result = fn.apply(this, args);
+    console.log(result);
+
+    return result;
+  };
+
+// @ts-ignore
+class Foo {
+  @wrap(wrapper)
+  public bar(num: number) {
+    return num * num;
+  }
+}

--- a/packages/transform-wrap/tests/fixtures/wrap/wrapper-within-regular/input.ts
+++ b/packages/transform-wrap/tests/fixtures/wrap/wrapper-within-regular/input.ts
@@ -1,0 +1,18 @@
+import {wrap} from '../../../../src';
+
+function wrapper(fn: Foo['bar']) {
+  return function (this: Foo, ...args: any[]) {
+    const result = fn.apply(this, args);
+    console.log(result);
+
+    return result;
+  };
+}
+
+// @ts-ignore
+class Foo {
+  @wrap(wrapper)
+  public bar(num: number) {
+    return num * num;
+  }
+}

--- a/packages/transform-wrap/tests/wrap.ts
+++ b/packages/transform-wrap/tests/wrap.ts
@@ -1,0 +1,117 @@
+import {transformFile as _transformFile} from '../../../utils/testing';
+import commonOptions from './fixtures/options';
+
+const transformFile = async (
+  fixture: string,
+  options?: string | object,
+): ReturnType<typeof _transformFile> =>
+  _transformFile(__dirname, 'wrap', fixture, options);
+
+describe('@ast-decorators/transform-wrap', () => {
+  describe('@wrap', () => {
+    describe('wrapper types', () => {
+      it('compiles for a method with inline arrow wrapper', async () => {
+        const {code} = await transformFile(
+          'wrapper-inline-arrow',
+          commonOptions,
+        );
+        expect(code).toMatchSnapshot();
+      });
+
+      it('compiles for a method with inline regular wrapper', async () => {
+        const {code} = await transformFile(
+          'wrapper-inline-regular',
+          commonOptions,
+        );
+        expect(code).toMatchSnapshot();
+      });
+
+      it('compiles for a method with wrapper declared in the same file as an arrow function', async () => {
+        const {code} = await transformFile(
+          'wrapper-within-arrow',
+          commonOptions,
+        );
+        expect(code).toMatchSnapshot();
+      });
+
+      it('compiles for a method with wrapper declared in the same file as a regular function', async () => {
+        const {code} = await transformFile(
+          'wrapper-within-regular',
+          commonOptions,
+        );
+        expect(code).toMatchSnapshot();
+      });
+
+      it('compiles for a method with wrapper imported from an external file', async () => {
+        const {code} = await transformFile(
+          'wrapper-import-default',
+          commonOptions,
+        );
+        expect(code).toMatchSnapshot();
+      });
+
+      it('compiles for a method with multiple wrappers', async () => {
+        const {code} = await transformFile('wrapper-multiple', commonOptions);
+        expect(code).toMatchSnapshot();
+      });
+
+      it('sends arguments to a wrapper function', async () => {
+        const {code} = await transformFile('wrapper-args', commonOptions);
+        expect(code).toMatchSnapshot();
+      });
+    });
+
+    describe('method', () => {
+      it('compiles for a private method', async () => {
+        const {code} = await transformFile('method-private', commonOptions);
+        expect(code).toMatchSnapshot();
+      });
+
+      it('compiles for a generator method', async () => {
+        const {code} = await transformFile('method-generator', commonOptions);
+        expect(code).toMatchSnapshot();
+      });
+
+      it('compiles for a private generator method', async () => {
+        const {code} = await transformFile(
+          'method-private-generator',
+          commonOptions,
+        );
+        expect(code).toMatchSnapshot();
+      });
+    });
+
+    describe('property', () => {
+      it('compiles for a property defined as an arrow function', async () => {
+        const {code} = await transformFile('property-arrow', commonOptions);
+        expect(code).toMatchSnapshot();
+      });
+
+      it('compiles for a property defined as a regular function', async () => {
+        const {code} = await transformFile('property-regular', commonOptions);
+        expect(code).toMatchSnapshot();
+      });
+
+      it('compiles for a private property', async () => {
+        const {code} = await transformFile('property-private', commonOptions);
+        expect(code).toMatchSnapshot();
+      });
+
+      it('fails if property does not have value', async () => {
+        await expect(
+          transformFile('property-no-function', commonOptions),
+        ).rejects.toThrowError(
+          '@wrap can only be applied to class methods or properties with function assigned',
+        );
+      });
+
+      it('fails if property has incorrect value', async () => {
+        await expect(
+          transformFile('property-incorrect-value', commonOptions),
+        ).rejects.toThrowError(
+          '@wrap can only be applied to class methods or properties with function assigned',
+        );
+      });
+    });
+  });
+});

--- a/packages/transform-wrap/tests/wrap.ts
+++ b/packages/transform-wrap/tests/wrap.ts
@@ -1,4 +1,5 @@
 import {transformFile as _transformFile} from '../../../utils/testing';
+import {wrap} from '../src';
 import commonOptions from './fixtures/options';
 
 const transformFile = async (
@@ -112,6 +113,15 @@ describe('@ast-decorators/transform-wrap', () => {
           '@wrap can only be applied to class methods or properties with function assigned',
         );
       });
+    });
+
+    it('fails if transformer is not plugged in', () => {
+      // @ts-expect-error: Here the runtime replacement used. It does not
+      // require arguments
+      expect(() => wrap()()).toThrowError(
+        "Decorator @wrap won't work because @ast-decorators/transform-wrap/lib/transformer" +
+          'is not plugged in. You have to add it to your Babel config',
+      );
     });
   });
 });

--- a/packages/transform-wrap/tsconfig.build.json
+++ b/packages/transform-wrap/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig",
+  "include": ["src/**/*"]
+}

--- a/packages/transform-wrap/tsconfig.json
+++ b/packages/transform-wrap/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "lib"
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/packages/utils/src/babelFixes.ts
+++ b/packages/utils/src/babelFixes.ts
@@ -1,10 +1,121 @@
-import {cloneNode} from '@babel/types';
-import {ClassMember} from './common';
+/* eslint-disable max-params */
+import {
+  BlockStatement,
+  classMethod as _classMethod,
+  ClassMethod,
+  classPrivateMethod as _classPrivateMethod,
+  ClassPrivateMethod,
+  ClassPrivateProperty,
+  classPrivateProperty as _classPrivateProperty,
+  cloneNode as _cloneNode,
+  Decorator,
+  Expression,
+  Identifier,
+  isClassPrivateProperty,
+  Node,
+  Noop,
+  NumericLiteral,
+  Pattern,
+  PrivateName,
+  RestElement,
+  StringLiteral,
+  TSParameterProperty,
+  TSTypeAnnotation,
+  TypeAnnotation,
+} from '@babel/types';
 
-export const cloneClassMember = <T extends ClassMember>(node: T): T => {
-  const cloned = cloneNode(node);
-  // @ts-expect-error: "static" is not listed in d.ts
-  cloned.static = node.static;
+export const cloneNode = <T extends Node>(
+  node: T,
+  deep?: boolean,
+  withoutLoc?: boolean,
+): T => {
+  const cloned = _cloneNode(node, deep, withoutLoc);
+
+  if (isClassPrivateProperty(node)) {
+    // @ts-expect-error: Babel d.ts file does not include "static" for
+    // ClassPrivateProperty and ClassPrivateMethod.
+    cloned.static = node.static;
+  }
 
   return cloned;
+};
+
+export const classMethod = (
+  kind: 'get' | 'set' | 'method' | 'constructor' | undefined,
+  key: Identifier | StringLiteral | NumericLiteral | Expression,
+  params: Array<Identifier | Pattern | RestElement | TSParameterProperty>,
+  body: BlockStatement,
+  decorators?: Decorator[] | null,
+  computed?: boolean,
+  _static?: boolean,
+  generator?: boolean,
+  async?: boolean,
+): ClassMethod => {
+  const node = _classMethod(
+    kind,
+    key,
+    params,
+    body,
+    computed,
+    _static,
+    generator,
+    async,
+  );
+
+  if (decorators !== undefined) {
+    node.decorators = decorators;
+  }
+
+  return node;
+};
+
+export const classPrivateProperty = (
+  key: PrivateName,
+  value?: Expression | null,
+  typeAnnotation?: TypeAnnotation | TSTypeAnnotation | Noop | null,
+  decorators?: Decorator[] | null,
+  _static?: boolean,
+): ClassPrivateProperty => {
+  const node = _classPrivateProperty(key, value, decorators);
+
+  if (typeAnnotation) {
+    // @ts-expect-error: Babel d.ts file does not include "typeAnnotation" for
+    // ClassPrivateProperty.
+    node.typeAnnotation = typeAnnotation;
+  }
+
+  if (_static) {
+    // @ts-expect-error: Babel d.ts file does not include "static" for
+    // ClassPrivateProperty.
+    node.static = _static;
+  }
+
+  return node;
+};
+
+export const classPrivateMethod = (
+  kind: 'get' | 'set' | 'method' | 'constructor' | undefined,
+  key: PrivateName,
+  params: Array<Identifier | Pattern | RestElement | TSParameterProperty>,
+  body: BlockStatement,
+  decorators?: Decorator[] | null,
+  _static?: boolean,
+  generator?: boolean,
+  async?: boolean,
+): ClassPrivateMethod => {
+  const node = _classPrivateMethod(kind, key, params, body, _static);
+
+  if (decorators !== undefined) {
+    node.decorators = decorators;
+  }
+
+  if (generator) {
+    node.generator = generator;
+  }
+
+  if (async) {
+    node.async = async;
+  }
+
+  return node;
 };

--- a/packages/utils/src/babelFixes.ts
+++ b/packages/utils/src/babelFixes.ts
@@ -1,0 +1,10 @@
+import {cloneNode} from '@babel/types';
+import {ClassMember} from './common';
+
+export const cloneClassMember = <T extends ClassMember>(node: T): T => {
+  const cloned = cloneNode(node);
+  // @ts-expect-error: "static" is not listed in d.ts
+  cloned.static = node.static;
+
+  return cloned;
+};

--- a/packages/utils/src/createPropertyByPrivacy.ts
+++ b/packages/utils/src/createPropertyByPrivacy.ts
@@ -11,16 +11,11 @@ import type {ClassMemberProperty, PrivacyType} from './common';
 
 const createSymbolAssignment = template.statement(`const VAR = Symbol()`);
 
-export type PropertyOptions = Readonly<{
-  static?: boolean;
-  value?: ClassProperty['value'];
-}>;
-
 const createPropertyByPrivacy = (
   privacy: PrivacyType,
   name: string | number | undefined,
   klass: NodePath<Class>,
-  {static: _static, value}: PropertyOptions = {},
+  options?: Partial<Pick<ClassProperty, 'decorators' | 'static' | 'value'>>,
 ): ClassMemberProperty => {
   const uid = name?.toString();
 
@@ -30,10 +25,14 @@ const createPropertyByPrivacy = (
       const id = classBody.scope.generateUidIdentifier(uid);
       const privateId = privateName(id);
 
-      const prop = classPrivateProperty(privateId, value, null);
+      const prop = classPrivateProperty(
+        privateId,
+        options?.value,
+        options?.decorators,
+      );
 
       // @ts-expect-error: "static" is not listed in d.ts
-      prop.static = _static;
+      prop.static = options?.static;
 
       return prop;
     }
@@ -41,13 +40,27 @@ const createPropertyByPrivacy = (
       const id = klass.parentPath.scope.generateUidIdentifier(uid);
       klass.insertBefore([createSymbolAssignment({VAR: id})]);
 
-      return classProperty(id, value, null, null, true);
+      return classProperty(
+        id,
+        options?.value,
+        null,
+        options?.decorators,
+        true,
+        options?.static,
+      );
     }
     default: {
       const classBody = klass.get('body');
       const id = classBody.scope.generateUidIdentifier(uid);
 
-      return classProperty(id, value);
+      return classProperty(
+        id,
+        options?.value,
+        null,
+        options?.decorators,
+        false,
+        options?.static,
+      );
     }
   }
 };

--- a/packages/utils/src/hoistFunctionParameter.ts
+++ b/packages/utils/src/hoistFunctionParameter.ts
@@ -12,14 +12,16 @@ import {
   VariableDeclaration,
 } from '@babel/types';
 
+export type FunctionParameter =
+  | FunctionExpression
+  | ArrowFunctionExpression
+  | Identifier
+  | MemberExpression;
+
 const declarator = template(`const VAR = FUNCTION`);
 
-const hoistParameterFunction = (
-  fn:
-    | FunctionExpression
-    | ArrowFunctionExpression
-    | Identifier
-    | MemberExpression,
+const hoistFunctionParameter = (
+  fn: FunctionParameter,
   name: string,
   scope: Scope,
 ): readonly [
@@ -51,4 +53,4 @@ const hoistParameterFunction = (
   ];
 };
 
-export default hoistParameterFunction;
+export default hoistFunctionParameter;

--- a/packages/utils/src/hoistParameterFunction.ts
+++ b/packages/utils/src/hoistParameterFunction.ts
@@ -1,0 +1,54 @@
+import template from '@babel/template';
+import type {Scope} from '@babel/traverse';
+import {
+  ArrowFunctionExpression,
+  functionDeclaration,
+  FunctionDeclaration,
+  FunctionExpression,
+  Identifier,
+  isArrowFunctionExpression,
+  isFunctionExpression,
+  MemberExpression,
+  VariableDeclaration,
+} from '@babel/types';
+
+const declarator = template(`const VAR = FUNCTION`);
+
+const hoistParameterFunction = (
+  fn:
+    | FunctionExpression
+    | ArrowFunctionExpression
+    | Identifier
+    | MemberExpression,
+  name: string,
+  scope: Scope,
+): readonly [
+  Identifier | MemberExpression,
+  FunctionDeclaration | VariableDeclaration | undefined,
+] => {
+  const isArrow = isArrowFunctionExpression(fn);
+  const isRegular = isFunctionExpression(fn);
+
+  const interceptorId =
+    isArrow || isRegular
+      ? scope.generateUidIdentifier(name)
+      : (fn as Identifier | MemberExpression);
+
+  return [
+    interceptorId,
+    isArrow
+      ? (declarator({
+          FUNCTION: fn,
+          VAR: interceptorId as Identifier,
+        }) as VariableDeclaration)
+      : isRegular
+      ? functionDeclaration(
+          interceptorId as Identifier,
+          (fn as FunctionExpression).params,
+          (fn as FunctionExpression).body,
+        )
+      : undefined,
+  ];
+};
+
+export default hoistParameterFunction;

--- a/packages/utils/tests/__snapshots__/hoistFunctionParameter.ts.snap
+++ b/packages/utils/tests/__snapshots__/hoistFunctionParameter.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@ast-decorators/utils hoistFunctionParameter hoists the arrow function parameter 1`] = `"const _param = (baz: number) => baz * 10;"`;
+
+exports[`@ast-decorators/utils hoistFunctionParameter hoists the regular function parameter 1`] = `
+"function _param(baz: number) {
+  return baz * 10;
+}"
+`;

--- a/packages/utils/tests/babelFixes.ts
+++ b/packages/utils/tests/babelFixes.ts
@@ -1,0 +1,88 @@
+import generate from '@babel/generator';
+import {
+  blockStatement,
+  ClassPrivateProperty,
+  classPrivateProperty as _classPrivateProperty,
+  cloneNode as _cloneNode,
+  identifier,
+  numericLiteral,
+  privateName,
+  tsNumberKeyword,
+  tsTypeAnnotation,
+} from '@babel/types';
+import {
+  classPrivateMethod,
+  classPrivateProperty,
+  cloneNode,
+  classMethod,
+} from '../src/babelFixes';
+
+describe('babelFixes', () => {
+  describe('cloneNode', () => {
+    it('fixes copying the ClassPrivateProperty "static" property', () => {
+      const node: ClassPrivateProperty = _classPrivateProperty(
+        privateName(identifier('foo')),
+        null,
+      );
+      // @ts-expect-error: Babel d.ts file does not include "static" for
+      // ClassPrivateProperty.
+      node.static = true;
+
+      // @ts-expect-error: Babel d.ts file does not include "static" for
+      // ClassPrivateProperty.
+      expect(_cloneNode(node).static).not.toBeTruthy();
+      // @ts-expect-error: Babel d.ts file does not include "static" for
+      // ClassPrivateProperty.
+      expect(cloneNode(node).static).toBeTruthy();
+    });
+  });
+
+  describe('classMethod', () => {
+    it('allows creating method with decorators', () => {
+      const node = classMethod(
+        'method',
+        identifier('foo'),
+        [],
+        blockStatement([]),
+        null,
+        false,
+        true,
+        true,
+        true,
+      );
+
+      expect(generate(node).code).toBe('static async *foo() {}');
+    });
+  });
+
+  describe('classPrivateProperty', () => {
+    it('allows creating private property with the same interface as regular property', () => {
+      const node = classPrivateProperty(
+        privateName(identifier('foo')),
+        numericLiteral(10),
+        tsTypeAnnotation(tsNumberKeyword()),
+        null,
+        true,
+      );
+
+      expect(generate(node).code).toBe('static #foo: number = 10;');
+    });
+  });
+
+  describe('classPrivateMethod', () => {
+    it('allows creating private method with the same interface as regular method', () => {
+      const node = classPrivateMethod(
+        'method',
+        privateName(identifier('foo')),
+        [],
+        blockStatement([]),
+        null,
+        true,
+        true,
+        true,
+      );
+
+      expect(generate(node).code).toBe('static async *#foo() {}');
+    });
+  });
+});

--- a/packages/utils/tests/fixtures/hoistFunctionParameter/options.ts
+++ b/packages/utils/tests/fixtures/hoistFunctionParameter/options.ts
@@ -1,0 +1,8 @@
+export default {
+  comments: false,
+  plugins: [
+    require('@babel/plugin-syntax-typescript'),
+    [require('@babel/plugin-syntax-decorators'), {legacy: true}],
+    require('@babel/plugin-syntax-class-properties'),
+  ],
+};

--- a/packages/utils/tests/fixtures/hoistFunctionParameter/parameter-arrow/input.ts
+++ b/packages/utils/tests/fixtures/hoistFunctionParameter/parameter-arrow/input.ts
@@ -1,0 +1,8 @@
+// @ts-ignore
+import decorate from './decorator';
+
+// @ts-ignore
+class Foo {
+  @decorate((baz: number) => baz * 10)
+  bar() {}
+}

--- a/packages/utils/tests/fixtures/hoistFunctionParameter/parameter-identifier-unique-name/input.ts
+++ b/packages/utils/tests/fixtures/hoistFunctionParameter/parameter-identifier-unique-name/input.ts
@@ -1,0 +1,12 @@
+// @ts-ignore
+import decorate from './decorator';
+// @ts-ignore
+import {_someUniqueVar} from './utils';
+
+// @ts-ignore
+class Foo {
+  baz = _someUniqueVar;
+
+  @decorate(() => {})
+  bar() {}
+}

--- a/packages/utils/tests/fixtures/hoistFunctionParameter/parameter-identifier/input.ts
+++ b/packages/utils/tests/fixtures/hoistFunctionParameter/parameter-identifier/input.ts
@@ -1,0 +1,10 @@
+// @ts-ignore
+import decorate from './decorator';
+// @ts-ignore
+import {fn} from './utils';
+
+// @ts-ignore
+class Foo {
+  @decorate(fn)
+  bar() {}
+}

--- a/packages/utils/tests/fixtures/hoistFunctionParameter/parameter-member-expression/input.ts
+++ b/packages/utils/tests/fixtures/hoistFunctionParameter/parameter-member-expression/input.ts
@@ -1,0 +1,10 @@
+// @ts-ignore
+import decorate from './decorator';
+// @ts-ignore
+import * as utils from './utils';
+
+// @ts-ignore
+class Foo {
+  @decorate(utils.fn)
+  bar() {}
+}

--- a/packages/utils/tests/fixtures/hoistFunctionParameter/parameter-regular/input.ts
+++ b/packages/utils/tests/fixtures/hoistFunctionParameter/parameter-regular/input.ts
@@ -1,0 +1,10 @@
+// @ts-ignore
+import decorate from './decorator';
+
+// @ts-ignore
+class Foo {
+  @decorate(function (baz: number) {
+    return baz * 10;
+  })
+  bar() {}
+}

--- a/packages/utils/tests/hoistFunctionParameter.ts
+++ b/packages/utils/tests/hoistFunctionParameter.ts
@@ -1,0 +1,116 @@
+import {NodePath, traverse} from '@babel/core';
+import generate from '@babel/generator';
+import {
+  CallExpression,
+  Class,
+  Decorator,
+  Identifier,
+  isClass,
+  isIdentifier,
+  isMemberExpression,
+} from '@babel/types';
+import {parseToAST as _parseToAST} from '../../../utils/testing';
+import hoistFunctionParameter, {
+  FunctionParameter,
+} from '../src/hoistFunctionParameter';
+import options from './fixtures/getMemberName/options';
+
+const parseToAST = async (fixture: string): ReturnType<typeof _parseToAST> =>
+  _parseToAST(__dirname, 'hoistFunctionParameter', fixture, options);
+
+const run = async (
+  fixture: string,
+  callback: (fn: FunctionParameter, classPath: NodePath<Class>) => void,
+): Promise<void> => {
+  const ast = await parseToAST(fixture);
+
+  await new Promise((resolve) => {
+    traverse(ast!, {
+      Decorator(path: NodePath<Decorator>) {
+        const [fn] = (path.node.expression as CallExpression).arguments;
+
+        // eslint-disable-next-line callback-return
+        callback(
+          fn as FunctionParameter,
+          path.findParent(({node}) => isClass(node)) as NodePath<Class>,
+        );
+        resolve();
+      },
+    });
+  });
+};
+
+describe('@ast-decorators/utils', () => {
+  describe('hoistFunctionParameter', () => {
+    it('hoists the arrow function parameter', async () => {
+      await run('parameter-arrow', (fn, classPath) => {
+        const [id, declaration] = hoistFunctionParameter(
+          fn,
+          'param',
+          classPath.parentPath.scope,
+        );
+
+        expect(isIdentifier(id)).toBeTruthy();
+        expect((id as Identifier).name).toBe('_param');
+        expect(declaration).not.toBeUndefined();
+        expect(generate(declaration!).code).toMatchSnapshot();
+      });
+    });
+
+    it('hoists the regular function parameter', async () => {
+      await run('parameter-regular', (fn, classPath) => {
+        const [id, declaration] = hoistFunctionParameter(
+          fn,
+          'param',
+          classPath.parentPath.scope,
+        );
+
+        expect(isIdentifier(id)).toBeTruthy();
+        expect((id as Identifier).name).toBe('_param');
+        expect(declaration).not.toBeUndefined();
+        expect(generate(declaration!).code).toMatchSnapshot();
+      });
+    });
+
+    it('gets the identifier parameter id', async () => {
+      await run('parameter-identifier', (fn, classPath) => {
+        const [id, declaration] = hoistFunctionParameter(
+          fn,
+          'param',
+          classPath.parentPath.scope,
+        );
+
+        expect(isIdentifier(id)).toBeTruthy();
+        expect((id as Identifier).name).toBe('fn');
+        expect(declaration).toBeUndefined();
+      });
+    });
+
+    it('gets the MemberExpression parameter id', async () => {
+      await run('parameter-member-expression', (fn, classPath) => {
+        const [id, declaration] = hoistFunctionParameter(
+          fn,
+          'param',
+          classPath.parentPath.scope,
+        );
+
+        expect(isMemberExpression(id)).toBeTruthy();
+        expect(generate(id).code).toBe('utils.fn');
+        expect(declaration).toBeUndefined();
+      });
+    });
+
+    it('changes the id of the hoisted parameter to be unique', async () => {
+      await run('parameter-identifier-unique-name', (fn, classPath) => {
+        const [id] = hoistFunctionParameter(
+          fn,
+          'someUniqueVar',
+          classPath.parentPath.scope,
+        );
+
+        expect(isIdentifier(id)).toBeTruthy();
+        expect((id as Identifier).name).toBe('_someUniqueVar2');
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR introduces a `@wrap` decorator that allows to transform the existing method.

## `@ast-decorators/transform-wrap`
### `@wrap`
This decorator replaces the existing method with the result of the decorator's argument. The argument receives the original method as an argument. `@wrap` decorator is method decorator; it cannot be applied to the class.

Mechanism description: the static property with the applied wrapped function is created. Original method calls it using the `this.constructor.<function name>` call.

**input.js**
```javascript
class Foo {
  @wrap(wrapper)
  bar(num) {
    return num * num;
  }
}
```

**output.js**
```javascript
class Foo {
  static #_bar = wrapper(function (num) {
    return num * num;
  });

  bar(...args) {
    return this.constructor.#_bar.apply(this, args);
  }
}
```

## `@ast-decorators/utils`
### `hoistFunctionParameter`
This utility is meant to move the decorator parameter declared as the function literal out of the class. Then the declaration id can be used in the transformed code. 

### `babelFixes`
This utility contains fixes for babel functions that have incorrect or inconvenient implementation. E.g., it has a fix for the `cloneNode` function that loses `static` parameter of the `ClassPrivateProperty` node.
